### PR TITLE
enable auto-mask and model chaining

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "spandrel>=0.4.1",
     "spandrel-extra-arches>=0.2.0",
     "tifftools>=1.6.0",
+    "sam2>=1.1.0",
+    "transformers>=4.57.3",
+    "timm>=1.0.22",
 ]
 
 [project.optional-dependencies]
@@ -35,11 +38,6 @@ cu126 = [
 mps = [
   "torch>=2.6.0",
   "torchvision",
-]
-detect = [
-  # TODO: This feature is not enabled by default and the deps may require local compilation.
-  # UV attempts to resolve all deps, including optionaly ones (https://github.com/astral-sh/uv/issues/6729).
-  # Removing these optional deps for now.
 ]
 
 [tool.uv]
@@ -63,11 +61,6 @@ torch = [
   { index = "pytorch-cpu", extra = "mps" },
 ]
 sam-2 = { git = "https://github.com/facebookresearch/sam2.git", rev = "c2ec8e14a185632b0a5d8b161928ceb50197eddc" }
-# For windows, prefer a prebuilt flash_attn wheel. https://huggingface.co/lldacing/flash-attention-windows-wheel/tree/main
-flash-attn = [
-  {url = "https://huggingface.co/lldacing/flash-attention-windows-wheel/resolve/main/flash_attn-2.7.4%2Bcu126torch2.6.0cxx11abiFALSE-cp312-cp312-win_amd64.whl?download=true", marker = "platform_system == 'Windows'"},
-  {git = "https://github.com/Dao-AILab/flash-attention.git", tag = "v2.8.1", marker = "platform_system != 'Windows'"}
-]
 
 [[tool.uv.index]]
 name = "pytorch-cpu"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "spandrel-extra-arches>=0.2.0",
     "tifftools>=1.6.0",
     "sam2>=1.1.0",
-    "transformers>=4.57.3",
+    "transformers>=4.57.3,<5",
     "timm>=1.0.22",
 ]
 

--- a/run.sh
+++ b/run.sh
@@ -29,4 +29,4 @@ uv sync --extra $torch_variant
 # Run
 echo "Starting Enhance AI..."
 uv run --no-sync src/setup/lrcPath.py
-uv run --no-sync src/main.py $*
+uv run --no-sync src/main.py "$@"

--- a/src/enhance/app.py
+++ b/src/enhance/app.py
@@ -225,7 +225,7 @@ class App:
 
         return opsToRerun
 
-    # TODO: Hard-coding values for tile size, padding, maintainScale, and device. These may differ from original run.
+    # TODO: Hard-coding values for tile size, padding, maintainScale, and device. These may differ from original run. Persist values from original run in the future.
     def rerunSingleOperation(
         self,
         compareFile: OutputFile,

--- a/src/enhance/app.py
+++ b/src/enhance/app.py
@@ -14,7 +14,7 @@ from huggingface_hub import HfApi
 
 
 from enhance.lib.util import Observable
-from enhance.lib.file import File, InputFile, OutputFile, Operation
+from enhance.lib.file import AppliedOperation, File, InputFile, OutputFile, Operation
 from enhance.lib.gpu import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -195,15 +195,12 @@ class App:
         if self.activeOperation:
             self.activeOperation.requestInterrupt()
 
-    def rerunOperationChain(
+    def prepareRerunChain(
         self,
         compareFile: OutputFile,
         startIndex: int,
-        progressCallback=None,
-        tileSize: int = 512,
-        tilePadding: int = 32,
-    ) -> bool:
-        """Re-run operations starting from the given index."""
+    ) -> list:
+        """Prepare to re-run operations from startIndex onward."""
         # Collect the operations that need to be re-run (from startIndex onwards)
         opsToRerun = list(compareFile.operations[startIndex:])
 
@@ -213,7 +210,7 @@ class App:
         # Reset the file path to the state before these operations
         if startIndex == 0:
             # Copy base file to cache and set as current path
-            rootPath = os.getcwd() + "/.cache/"
+            rootPath = os.path.normpath(os.path.join(os.getcwd(), ".cache"))
             if not os.path.exists(rootPath):
                 os.makedirs(rootPath)
             baseName = os.path.basename(compareFile.baseFile.path)
@@ -226,43 +223,51 @@ class App:
             # Use reapplyStrength to regenerate from previous operations
             compareFile.reapplyStrength(compareFile.operations[-1])
 
-        # Get preferred device
+        return opsToRerun
+
+    # TODO: Hard-coding values for tile size, padding, maintainScale, and device. These may differ from original run.
+    def rerunSingleOperation(
+        self,
+        compareFile: OutputFile,
+        op: AppliedOperation,
+        progressCallback=None,
+        tileSize: int = 512,
+        tilePadding: int = 32,
+    ) -> bool:
+        """Re-run a single operation on the current state of compareFile."""
         device = self.gpuInfo.getPreferredDevice()
+        maintainScale = op.scale is not None and op.scale < 1.0
 
-        # Re-run each operation
-        for op in opsToRerun:
-            maintainScale = op.scale is not None and op.scale < 1.0
+        runner = modelRunner.ModelRunner(
+            op.modelPath,
+            tileSize,
+            tilePadding,
+            maintainScale,
+            device,
+            modelRoot=self.getModelRoot(),
+        )
+        if progressCallback:
+            runner.addObserver(progressCallback)
+        self.activeOperation = runner
 
-            runner = modelRunner.ModelRunner(
-                op.modelPath,
-                tileSize,
-                tilePadding,
-                maintainScale,
-                device,
-                modelRoot=self.getModelRoot(),
-            )
-            if progressCallback:
-                runner.addObserver(progressCallback)
-            self.activeOperation = runner
+        result = runner.runOnExisting(
+            compareFile,
+            op.operation_type,
+            masks=op.masks if op.masks else None,
+        )
 
-            result = runner.runOnExisting(
-                compareFile,
-                op.operation_type,
-                masks=op.masks if op.masks else None,
-            )
+        if progressCallback:
+            runner.removeObserver(progressCallback)
 
-            if progressCallback:
-                runner.removeObserver(progressCallback)
+        if result is None:
+            logger.error(f"Failed to re-run operation: {op.operation_type}")
+            return False
 
-            if result is None:
-                logger.error(f"Failed to re-run operation: {op.operation_type}")
-                return False
-
-            # Apply the strength from the original operation
-            newOp = compareFile.operations[-1]
-            if newOp.supportsStrength() and op.strength is not None:
-                newOp.strength = op.strength
-                compareFile.reapplyStrength(newOp)
+        # Apply the strength from the original operation
+        newOp = compareFile.operations[-1]
+        if newOp.supportsStrength() and op.strength is not None:
+            newOp.strength = op.strength
+            compareFile.reapplyStrength(newOp)
 
         return True
 
@@ -285,7 +290,7 @@ class App:
             return {}
 
     def storeModels(self, models):
-        modelListPath = self.getModelPath() + MODEL_CONFIG
+        modelListPath = self.getModelRoot() + MODEL_CONFIG
         with open(modelListPath, "w") as f:
             json.dump(models, f, indent=4)
 

--- a/src/enhance/lib/file.py
+++ b/src/enhance/lib/file.py
@@ -41,11 +41,23 @@ class File(Unpickle):
 
 
 class Mask:
-    def __init__(self, score: float, label: str, mask: np.ndarray, box: tuple):
+
+    def __init__(
+        self,
+        score: float,
+        label: str,
+        mask: np.ndarray,
+        box: tuple,
+        uniqueLabel: str = None,
+        inverted: bool = False,
+    ):
         self.score = score
         self.label = label
         self.mask = mask
         self.box = box
+        # Unique label for this mask instance (e.g., "person_1", "person_2")
+        self.uniqueLabel = uniqueLabel if uniqueLabel else label
+        self.inverted = inverted
 
 
 class Label:
@@ -60,40 +72,241 @@ class InputFile(File):
         self.masks: list[Mask] = []
         self.labels: list[Label] = []
 
+    def addMask(self, mask: Mask):
+        """Add a mask with a unique label"""
+        # Count existing masks with the same base label
+        count = sum(1 for m in self.masks if m.label == mask.label)
+        if count > 0:
+            mask.uniqueLabel = f"{mask.label}_{count + 1}"
+        else:
+            # Check if there's already a mask with this label
+            existing = [m for m in self.masks if m.label == mask.label]
+            if existing:
+                # Rename the first one
+                existing[0].uniqueLabel = f"{mask.label}_1"
+                mask.uniqueLabel = f"{mask.label}_2"
+            else:
+                mask.uniqueLabel = mask.label
+        self.masks.append(mask)
 
-class PostProcessOperationDeprecated(Enum):
-    Blur = "Blur"
-    Downscale = "Downscale"
-    Blend = "Blend"
+
+class Operation(Enum):
+    Sharpen = "sharpen"
+    Denoise = "denoise"
+    Upscale = "upscale"
 
 
-class PostProcessOperation:
-    def execute(self, img, file: File):
-        raise NotImplementedError("Not implemented")
+class AppliedOperation:
+    """Represents an operation applied to an OutputFile"""
 
-    def getPathExtra(self):
-        raise NotImplementedError("Not implemented")
+    DEFAULT_STRENGTH = 0.8  # 80% strength by default for model operations
+
+    def __init__(
+        self,
+        operation_type: Operation = None,
+        model: str = None,
+        modelPath: str = None,
+        strength: float = None,
+        scale: float = None,
+        masks: List["Mask"] = None,
+    ):
+        self.operation_type = operation_type  # For model operations
+        self.model = model  # For model operations (display name)
+        self.modelPath = (
+            modelPath  # For model operations (original path for re-running)
+        )
+        # Scale factor for model operations (e.g., 0.5 means downscale 2X to maintain original dimensions)
+        self.scale = scale
+        # Strength for model operations (0.0-1.0, where 1.0 = full effect)
+        if strength is None:
+            if operation_type in (Operation.Sharpen, Operation.Denoise):
+                self.strength = self.DEFAULT_STRENGTH
+            elif (
+                operation_type == Operation.Upscale
+                and scale is not None
+                and scale < 1.0
+            ):
+                self.strength = self.DEFAULT_STRENGTH
+            else:
+                self.strength = strength
+        else:
+            self.strength = strength
+        # Path to the raw (unblended, unscaled) model output
+        self.rawOutputPath: str = None
+        # List of masks to apply to this operation (only process within masked regions)
+        self.masks: List["Mask"] = masks if masks is not None else []
+
+    def getPathExtra(self) -> str:
+        if self.operation_type and self.model:
+            base = f"_{self.operation_type.value}_{self.model}"
+            # Include strength in path if not 100%
+            if self.strength is not None and self.strength < 1.0:
+                base += f"_s{int(self.strength * 100)}"
+            # Include scale in path if downscaling
+            if self.scale is not None and self.scale < 1.0:
+                base += f"_d{int(1/self.scale)}X"
+            # Include mask labels if any
+            if self.masks:
+                # Separate inside and outside masks for path naming
+                inside_masks = [m for m in self.masks if not m.inverted]
+                outside_masks = [m for m in self.masks if m.inverted]
+                if inside_masks:
+                    inside_labels = "_".join(m.uniqueLabel for m in inside_masks)
+                    base += f"_m{inside_labels}"
+                if outside_masks:
+                    outside_labels = "_".join(m.uniqueLabel for m in outside_masks)
+                    base += f"_minv{outside_labels}"
+            return base
+        return ""
+
+    def supportsStrength(self) -> bool:
+        if self.operation_type in (Operation.Sharpen, Operation.Denoise):
+            return True
+        if (
+            self.operation_type == Operation.Upscale
+            and self.scale is not None
+            and self.scale < 1.0
+        ):
+            return True
+        return False
 
 
 class OutputFile(File):
 
-    def __init__(self, path, baseFile: File, operation=None, model=None, postprocess: dict = None):
+    def __init__(self, path, baseFile: File):
         super().__init__(path)
 
         self.baseFile = baseFile
-        self.operation = operation
-        self.model = model
         self.origPath = path
-        self.postops: List[PostProcessOperation] = []
 
-    def applyPostProcessAndSave(self):
-        img = cv2.imread(self.origPath, cv2.IMREAD_UNCHANGED)
-        for postop in self.postops:
-            if isinstance(postop, PostProcessOperation):
-                img = postop.execute(img, self)
-            else:
-                raise ValueError("Invalid post process operation")
-        self.saveImageToCache(img)
+        # List of all operations (both model and post-process)
+        self.operations: List[AppliedOperation] = []
+
+    def getFirstOperation(self) -> AppliedOperation:
+        """Get the first operation, or None if none exist"""
+        return self.operations[0] if self.operations else None
+
+    def getOperationIndex(self, operation: AppliedOperation) -> int:
+        """Get the index of an operation, or -1 if not found"""
+        for i, op in enumerate(self.operations):
+            if op is operation:
+                return i
+        return -1
+
+    def removeOperationsFrom(self, index: int):
+        """Remove all operations from the given index onwards"""
+        if index >= 0 and index < len(self.operations):
+            self.operations = self.operations[:index]
+
+    def addOperation(
+        self,
+        operation_type: Operation = None,
+        model: str = None,
+        modelPath: str = None,
+        strength: float = None,
+        scale: float = None,
+        masks: List[Mask] = None,
+    ) -> AppliedOperation:
+        """Add an operation to this output file"""
+        self.operations.append(
+            AppliedOperation(
+                operation_type=operation_type,
+                model=model,
+                modelPath=modelPath,
+                strength=strength,
+                scale=scale,
+                masks=masks,
+            )
+        )
+
+        return self.operations[-1]
+
+    def applyScale(self, img, operation: AppliedOperation):
+        """Apply scaling for a model operation (e.g., downscale to maintain original size)"""
+        if operation.scale is None or operation.scale >= 1.0:
+            return img
+
+        scaled = cv2.resize(img, None, fx=operation.scale, fy=operation.scale, interpolation=cv2.INTER_AREA)
+        return scaled
+
+    def saveRawModelOutput(self, img, operation: AppliedOperation):
+        """Save the raw (unblended) model output for later strength adjustment"""
+        rootPath = os.getcwd() + "/.cache/"
+        if not os.path.exists(rootPath):
+            os.makedirs(rootPath)
+        baseName = os.path.basename(self.baseFile.path)
+        base, ext = os.path.splitext(baseName)
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+
+        # Save raw output with _raw suffix
+        rawPath = os.path.join(rootPath, f"{base}_{operation.operation_type.value}_{operation.model}_raw_{timestamp}{ext}")
+
+        logger.info(f"Saving raw model output to: {rawPath}")
+        if ext.lower() in [".tif", ".tiff"]:
+            writeTiffFile(img, self.baseFile.path, rawPath)
+        else:
+            writeFile(img, self.baseFile.path, rawPath)
+
+        operation.rawOutputPath = rawPath
+        return rawPath
+
+    def applyStrengthBlending(self, img, operation: AppliedOperation, inputImg):
+        if not operation.supportsStrength() or operation.strength is None or operation.strength >= 1.0:
+            return img
+
+        if inputImg is None:
+            logger.warning("No input image for blending")
+            return img
+
+        # Resize input if dimensions don't match (e.g., after upscale)
+        if inputImg.shape != img.shape:
+            inputImg = cv2.resize(
+                inputImg, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC
+            )
+
+        # Blend: result = strength * model_output + (1 - strength) * input
+        strength = operation.strength
+        blendedImg = cv2.addWeighted(img, strength, inputImg, 1 - strength, 0)
+        return blendedImg
+
+    def reapplyStrength(self, operation: AppliedOperation):
+        """Reapply all operations with their current strengths.
+
+        When any operation's strength changes, we need to reprocess all operations
+        in sequence since later operations depend on the results of earlier ones.
+        """
+        # Start with the base file
+        currentImg = cv2.imread(self.baseFile.path, cv2.IMREAD_UNCHANGED)
+        if currentImg is None:
+            logger.warning(f"Could not read base file: {self.baseFile.path}")
+            return False
+
+        # Process all operations in sequence
+        for op in self.operations:
+            if op.rawOutputPath is None or not os.path.exists(op.rawOutputPath):
+                logger.warning(
+                    f"Raw output not found for operation: {op.rawOutputPath}"
+                )
+                continue
+
+            # Load this operation's raw output
+            rawImg = cv2.imread(op.rawOutputPath, cv2.IMREAD_UNCHANGED)
+            if rawImg is None:
+                logger.warning(f"Could not read raw output: {op.rawOutputPath}")
+                continue
+
+            # Apply post processing
+            blendedImg = self.applyStrengthBlending(rawImg, op, currentImg)
+            blendedImg = self.applyScale(blendedImg, op)
+            currentImg = blendedImg
+
+        # Save the final result
+        self.saveImageToCache(currentImg)
+        return True
+
+        # Save the result
+        self.saveImageToCache(blendedImg)
+        return True
 
     def saveImageToCache(self, img):
         # Determine path based on applied operations
@@ -104,8 +317,8 @@ class OutputFile(File):
         base, ext = os.path.splitext(baseName)
         timestamp = time.strftime("%Y%m%d-%H%M%S")
 
-        pathExtra = f"_{self.operation.value}_{self.model}"
-        pathExtra = pathExtra + "".join(list(map(lambda x: x.getPathExtra(), self.postops)))
+        # Build path from all operations
+        pathExtra = "".join(op.getPathExtra() for op in self.operations)
 
         outpath = os.path.join(rootPath, base + pathExtra + "_" + timestamp + ext)
 
@@ -129,50 +342,3 @@ class OutputFile(File):
         super().setPath(path)
         if self.origPath is None:
             self.origPath = path
-
-
-class DownscaleOperation(PostProcessOperation):
-    def __init__(self, scale: float):
-        super().__init__()
-        self.scale = scale
-        self.method = cv2.INTER_AREA
-        self.editable = False
-
-    def execute(self, img, file: OutputFile):
-        img = cv2.resize(img, None, fx=self.scale, fy=self.scale, interpolation=self.method)
-        return img
-
-    def getPathExtra(self):
-        return f"_downscale_{int(1/self.scale)}X"
-
-
-class BlendOperation(PostProcessOperation):
-    def __init__(self, factor: float):
-        super().__init__()
-        self.factor = factor
-        self.editable = True
-
-    def execute(self, img, file: OutputFile):
-        baseImg = cv2.imread(file.baseFile.path, cv2.IMREAD_UNCHANGED)
-        if baseImg.shape != img.shape:
-            baseImg = cv2.resize(
-                baseImg, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_CUBIC
-            )
-        blendedImg = cv2.addWeighted(baseImg, self.factor, img, 1 - self.factor, 0)
-        return blendedImg
-
-    def getPathExtra(self):
-        return f"_blend_{self.factor}"
-
-
-class BlurOperation(PostProcessOperation):
-    def __init__(self, kernelSize: int):
-        super().__init__()
-        self.kernelSize = kernelSize
-        self.editable = True
-
-    def execute(self, img, file: OutputFile):
-        return cv2.GaussianBlur(img, (self.kernelSize, self.kernelSize), 0)
-
-    def getPathExtra(self):
-        return f"_blur_{self.kernelSize}"

--- a/src/enhance/lib/file.py
+++ b/src/enhance/lib/file.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import hashlib
 import os
 import shutil
 import time
@@ -11,6 +12,11 @@ import logging
 from enhance.ui.common import writeTiffFile, writeFile
 
 logger = logging.getLogger(__name__)
+
+
+# Leave headroom below Windows MAX_PATH (260) for temp-file suffixes
+# that libraries like tifftools append during writes.
+_MAX_FILENAME_PATH = 240
 
 
 class Unpickle:
@@ -151,10 +157,10 @@ class AppliedOperation:
                 inside_masks = [m for m in self.masks if not m.inverted]
                 outside_masks = [m for m in self.masks if m.inverted]
                 if inside_masks:
-                    inside_labels = "_".join(m.uniqueLabel for m in inside_masks)
+                    inside_labels = "_".join(m.uniqueLabel.replace(" ", "-") for m in inside_masks)
                     base += f"_m{inside_labels}"
                 if outside_masks:
-                    outside_labels = "_".join(m.uniqueLabel for m in outside_masks)
+                    outside_labels = "_".join(m.uniqueLabel.replace(" ", "-") for m in outside_masks)
                     base += f"_minv{outside_labels}"
             return base
         return ""
@@ -231,7 +237,7 @@ class OutputFile(File):
 
     def saveRawModelOutput(self, img, operation: AppliedOperation):
         """Save the raw (unblended) model output for later strength adjustment"""
-        rootPath = os.getcwd() + "/.cache/"
+        rootPath = os.path.normpath(os.path.join(os.getcwd(), ".cache"))
         if not os.path.exists(rootPath):
             os.makedirs(rootPath)
         baseName = os.path.basename(self.baseFile.path)
@@ -239,7 +245,9 @@ class OutputFile(File):
         timestamp = time.strftime("%Y%m%d-%H%M%S")
 
         # Save raw output with _raw suffix
-        rawPath = os.path.join(rootPath, f"{base}_{operation.operation_type.value}_{operation.model}_raw_{timestamp}{ext}")
+        rawFilename = f"{base}_{operation.operation_type.value}_{operation.model}_raw_{timestamp}{ext}"
+        rawFilename = _truncate_path(rootPath, rawFilename)
+        rawPath = os.path.join(rootPath, rawFilename)
 
         logger.info(f"Saving raw model output to: {rawPath}")
         if ext.lower() in [".tif", ".tiff"]:
@@ -304,13 +312,9 @@ class OutputFile(File):
         self.saveImageToCache(currentImg)
         return True
 
-        # Save the result
-        self.saveImageToCache(blendedImg)
-        return True
-
     def saveImageToCache(self, img):
         # Determine path based on applied operations
-        rootPath = os.getcwd() + "/.cache/"
+        rootPath = os.path.normpath(os.path.join(os.getcwd(), ".cache"))
         if not os.path.exists(rootPath):
             os.makedirs(rootPath)
         baseName = os.path.basename(self.baseFile.path)
@@ -320,7 +324,9 @@ class OutputFile(File):
         # Build path from all operations
         pathExtra = "".join(op.getPathExtra() for op in self.operations)
 
-        outpath = os.path.join(rootPath, base + pathExtra + "_" + timestamp + ext)
+        filename = base + pathExtra + "_" + timestamp + ext
+        filename = _truncate_path(rootPath, filename)
+        outpath = os.path.join(rootPath, filename)
 
         logger.info(f"Saving {img.dtype} image to cache: {outpath}")
         if ext.lower() in [".tif", ".tiff"]:
@@ -342,3 +348,22 @@ class OutputFile(File):
         super().setPath(path)
         if self.origPath is None:
             self.origPath = path
+
+def _truncate_path(directory: str, filename: str) -> str:
+    """Truncate filename if the full path would exceed the safe limit."""
+    directory = os.path.normpath(directory)
+    full = os.path.join(directory, filename)
+    if len(full) <= _MAX_FILENAME_PATH:
+        return filename
+    
+    base, ext = os.path.splitext(filename)
+    # 8-char hex hash for uniqueness
+    digest = hashlib.md5(base.encode()).hexdigest()[:8]
+    # How much space is available for the base name?
+    # directory + separator + base + "_" + hash + extension
+    overhead = len(directory) + 1 + 1 + len(digest) + len(ext)
+    max_base = _MAX_FILENAME_PATH - overhead
+    if max_base < 1:
+        max_base = 1
+    truncated = base[:max_base] + "_" + digest + ext
+    return truncated

--- a/src/enhance/lib/file.py
+++ b/src/enhance/lib/file.py
@@ -80,19 +80,21 @@ class InputFile(File):
 
     def addMask(self, mask: Mask):
         """Add a mask with a unique label"""
-        # Count existing masks with the same base label
-        count = sum(1 for m in self.masks if m.label == mask.label)
-        if count > 0:
-            mask.uniqueLabel = f"{mask.label}_{count + 1}"
+        # Find existing masks with the same base label
+        existing = [m for m in self.masks if m.label == mask.label]
+        count = len(existing)
+
+        if count == 0:
+            # First mask with this label - no numbering needed yet
+            mask.uniqueLabel = mask.label
+        elif count == 1:
+            # Second mask with this label - rename the first one and number both
+            existing[0].uniqueLabel = f"{mask.label}_1"
+            mask.uniqueLabel = f"{mask.label}_2"
         else:
-            # Check if there's already a mask with this label
-            existing = [m for m in self.masks if m.label == mask.label]
-            if existing:
-                # Rename the first one
-                existing[0].uniqueLabel = f"{mask.label}_1"
-                mask.uniqueLabel = f"{mask.label}_2"
-            else:
-                mask.uniqueLabel = mask.label
+            # Third or later - just number the new one
+            mask.uniqueLabel = f"{mask.label}_{count + 1}"
+
         self.masks.append(mask)
 
 
@@ -290,16 +292,17 @@ class OutputFile(File):
         # Process all operations in sequence
         for op in self.operations:
             if op.rawOutputPath is None or not os.path.exists(op.rawOutputPath):
-                logger.warning(
-                    f"Raw output not found for operation: {op.rawOutputPath}"
+                logger.error(
+                    f"Raw output not found for operation: {op.rawOutputPath}. "
+                    "Cannot rebuild chain."
                 )
-                continue
+                return False
 
             # Load this operation's raw output
             rawImg = cv2.imread(op.rawOutputPath, cv2.IMREAD_UNCHANGED)
             if rawImg is None:
-                logger.warning(f"Could not read raw output: {op.rawOutputPath}")
-                continue
+                logger.error(f"Could not read raw output: {op.rawOutputPath}")
+                return False
 
             # Apply post processing
             blendedImg = self.applyStrengthBlending(rawImg, op, currentImg)

--- a/src/enhance/lib/file.py
+++ b/src/enhance/lib/file.py
@@ -103,9 +103,9 @@ class Operation(Enum):
 
 
 class AppliedOperation:
-    """Represents an operation applied to an OutputFile"""
+    """Represents a model operation (sharpen/denoise/upscale) applied to an OutputFile"""
 
-    DEFAULT_STRENGTH = 0.8  # 80% strength by default for model operations
+    DEFAULT_STRENGTH = 0.8  # 80% strength by default
 
     def __init__(
         self,
@@ -116,14 +116,12 @@ class AppliedOperation:
         scale: float = None,
         masks: List["Mask"] = None,
     ):
-        self.operation_type = operation_type  # For model operations
-        self.model = model  # For model operations (display name)
-        self.modelPath = (
-            modelPath  # For model operations (original path for re-running)
-        )
-        # Scale factor for model operations (e.g., 0.5 means downscale 2X to maintain original dimensions)
+        self.operation_type = operation_type
+        self.model = model  # Display name
+        self.modelPath = modelPath  # Original path for re-running
+        # Scale factor (e.g., 0.5 means downscale 2X to maintain original dimensions)
         self.scale = scale
-        # Strength for model operations (0.0-1.0, where 1.0 = full effect)
+        # Strength (0.0-1.0, where 1.0 = full effect)
         if strength is None:
             if operation_type in (Operation.Sharpen, Operation.Denoise):
                 self.strength = self.DEFAULT_STRENGTH
@@ -185,7 +183,7 @@ class OutputFile(File):
         self.baseFile = baseFile
         self.origPath = path
 
-        # List of all operations (both model and post-process)
+        # List of model operations applied to this file
         self.operations: List[AppliedOperation] = []
 
     def getFirstOperation(self) -> AppliedOperation:

--- a/src/enhance/lib/gpu.py
+++ b/src/enhance/lib/gpu.py
@@ -45,6 +45,14 @@ class GPUInfo:
     def getGpuPresent(self):
         return self.cudaAvailable or self.mpsAvailable
 
+    def getPreferredDevice(self) -> str:
+        """Return the preferred device name - GPU if available, otherwise 'cpu'."""
+        if self.cudaAvailable:
+            return "cuda:0"
+        elif self.mpsAvailable:
+            return "mps"
+        return "cpu"
+
     def getGpuMemory(self) -> Tuple[float, float]:  # Return (total GB, available GB)
         try:
             if self.mpsAvailable:

--- a/src/enhance/op/florence.py
+++ b/src/enhance/op/florence.py
@@ -1,3 +1,8 @@
+import os
+
+# Set environment variable to suppress trust_remote_code prompts
+os.environ["HF_HUB_DISABLE_INTERACTIVE_TRUST_REMOTE_CODE"] = "1"
+
 import torch
 from transformers import AutoProcessor, AutoModelForCausalLM
 from PIL import Image
@@ -13,18 +18,29 @@ class GenerateLabels(Observable):
     def __init__(self, device):
         super().__init__()
         self.device = device
+        # Load model and processor once during initialization
+        self.florence2_model = (
+            AutoModelForCausalLM.from_pretrained(
+                FLORENCE2_MODEL_ID,
+                trust_remote_code=True,
+                torch_dtype="auto",
+                attn_implementation="eager",
+            )
+            .eval()
+            .to(self.device)
+        )
+        self.florence2_processor = AutoProcessor.from_pretrained(
+            FLORENCE2_MODEL_ID, trust_remote_code=True
+        )
 
     def detect(self, inFile: InputFile):
         img = Image.open(inFile.path).convert("RGB")
         return self.run(img)
 
     def run(self, img):
-        # FYI: Forcing revision=pr/27. https://github.com/huggingface/transformers/issues/37712
-        florence2_model = AutoModelForCausalLM.from_pretrained(
-            FLORENCE2_MODEL_ID, trust_remote_code=True, torch_dtype='auto',  revision="pr/27").eval().to(self.device)
-        florence2_processor = AutoProcessor.from_pretrained(FLORENCE2_MODEL_ID, trust_remote_code=True)
-
-        results = run_florence2(TASK_PROMPT, None, florence2_model, florence2_processor, img)
+        results = run_florence2(
+            TASK_PROMPT, None, self.florence2_model, self.florence2_processor, img
+        )
         return results[TASK_PROMPT]
 
 
@@ -36,19 +52,28 @@ def run_florence2(task_prompt, text_input, model, processor, image):
     else:
         prompt = task_prompt + text_input
 
-    inputs = processor(text=prompt, images=image, return_tensors="pt").to(device, torch.float16)
+    # Convert numpy array to PIL Image if needed
+    if hasattr(image, "shape"):  # numpy array
+        from PIL import Image as PILImage
+
+        pil_image = PILImage.fromarray(image)
+        image_size = (pil_image.width, pil_image.height)
+    else:  # already PIL Image
+        pil_image = image
+        image_size = (image.width, image.height)
+
+    inputs = processor(text=prompt, images=pil_image, return_tensors="pt").to(
+        device, torch.float16
+    )
     generated_ids = model.generate(
         input_ids=inputs["input_ids"].to(device),
         pixel_values=inputs["pixel_values"].to(device),
         max_new_tokens=1024,
-        early_stopping=False,
         do_sample=False,
-        num_beams=3,
+        use_cache=False,  # Disable caching to avoid past_key_values issues
     )
     generated_text = processor.batch_decode(generated_ids, skip_special_tokens=False)[0]
     parsed_answer = processor.post_process_generation(
-        generated_text,
-        task=task_prompt,
-        image_size=(image.width, image.height)
+        generated_text, task=task_prompt, image_size=image_size
     )
     return parsed_answer

--- a/src/enhance/op/florence.py
+++ b/src/enhance/op/florence.py
@@ -18,7 +18,6 @@ class GenerateLabels(Observable):
     def __init__(self, device):
         super().__init__()
         self.device = device
-        # Load model and processor once during initialization
         self.florence2_model = (
             AutoModelForCausalLM.from_pretrained(
                 FLORENCE2_MODEL_ID,
@@ -34,8 +33,11 @@ class GenerateLabels(Observable):
         )
 
     def detect(self, inFile: InputFile):
+        self.startJob(1)
         img = Image.open(inFile.path).convert("RGB")
-        return self.run(img)
+        result = self.run(img)
+        self.updateJob(1)
+        return result
 
     def run(self, img):
         results = run_florence2(

--- a/src/enhance/op/masks.py
+++ b/src/enhance/op/masks.py
@@ -37,7 +37,7 @@ class GenerateMasks(Observable):
                     mask=maskResults['masks'][i],
                     box=maskResults['bboxes'][i]
                 )
-                inFile.masks.append(mask)
+                inFile.addMask(mask)
 
         self.updateJob(1)
         return len(maskResults['masks']) > 0

--- a/src/enhance/op/model_runner.py
+++ b/src/enhance/op/model_runner.py
@@ -1,7 +1,8 @@
 import os
 import cv2
-from enhance.app import Operation
-from enhance.lib.file import DownscaleOperation, File, OutputFile
+import numpy as np
+from typing import List
+from enhance.lib.file import File, OutputFile, Operation, Mask
 from enhance.lib.util import Observable
 from enhance.op.simple_tile_processor import TileProcessor
 
@@ -11,23 +12,63 @@ import spandrel_extra_arches
 spandrel_extra_arches.install()
 
 
+def combine_masks(masks: List[Mask]) -> np.ndarray:
+    """Combine multiple masks into a single binary mask."""
+    if not masks:
+        return None
+
+    # Separate masks by inversion state
+    inside_masks = [m for m in masks if not m.inverted]
+    outside_masks = [m for m in masks if m.inverted]
+
+    # Determine shape from first mask
+    shape = masks[0].mask.shape
+
+    # Combine inside masks
+    if inside_masks:
+        combined = np.zeros(shape, dtype=np.float32)
+        for mask in inside_masks:
+            mask_arr = mask.mask.astype(np.float32)
+            if mask_arr.max() > 1.0:
+                mask_arr = mask_arr / mask_arr.max()
+            combined = np.maximum(combined, mask_arr)
+    else:
+        # No inside masks, start with full image
+        combined = np.ones(shape, dtype=np.float32)
+
+    # Combine outside masks
+    for mask in outside_masks:
+        mask_arr = mask.mask.astype(np.float32)
+        if mask_arr.max() > 1.0:
+            mask_arr = mask_arr / mask_arr.max()
+        # Invert this mask and AND with combined
+        inverted_mask = 1.0 - mask_arr
+        combined = np.minimum(combined, inverted_mask)
+
+    return combined
+
+
 class ModelRunner(Observable):
+
     def __init__(
         self,
-        modelPath: str,
+        modelKey: str,
         tileSize: int,
         tilePadding: int,
         maintainScale: bool,
         device: str,
+        modelRoot: str = "models/",
     ):
         super().__init__()
 
-        self.modelPath = modelPath
+        self.modelKey = modelKey
+        self.modelRoot = modelRoot
+        self.modelPath = os.path.join(modelRoot, modelKey)
         self.device = device if device is not None else "cpu"
 
-        fileBaseName = os.path.basename(modelPath)
+        fileBaseName = os.path.basename(self.modelPath)
         fileBaseName, _ = os.path.splitext(fileBaseName)
-        modelDir = os.path.dirname(modelPath)
+        modelDir = os.path.dirname(self.modelPath)
         dirBaseName = os.path.basename(modelDir)
         dirBaseName, _ = os.path.splitext(dirBaseName)
         self.modelName = dirBaseName + "_" + fileBaseName
@@ -36,9 +77,17 @@ class ModelRunner(Observable):
         self.tilePadding = tilePadding
         self.maintainScale = maintainScale
 
-    def run(self, inFile: File):
+    def run(
+        self,
+        inFile: File,
+        operation: Operation = Operation.Sharpen,
+        masks: List[Mask] = None,
+    ):
         model = ModelLoader().load_from_file(self.modelPath)
         assert isinstance(model, ImageModelDescriptor)
+
+        # Combine masks if provided
+        combinedMask = combine_masks(masks) if masks else None
 
         processor = TileProcessor(
             model=model,
@@ -47,6 +96,7 @@ class ModelRunner(Observable):
             scale=model.scale,
             device=self.device,
             observer=self,
+            mask=combinedMask,
         )
 
         imgPath = inFile.path
@@ -55,11 +105,93 @@ class ModelRunner(Observable):
         if output is None:
             return None
 
-        # TODO: Fix this signature
-        outputFile = OutputFile(None, inFile, Operation.Sharpen, self.modelName)
-        outputFile.saveImageToCache(output)
+        # Determine scale factor if maintaining original dimensions
+        scaleFactor = None
         if self.maintainScale and model.scale > 1:
-            outputFile.postops.append(DownscaleOperation(1 / model.scale))
-        outputFile.applyPostProcessAndSave()  # Apply any postprocess ops and save
+            scaleFactor = 1 / model.scale
+
+        outputFile = OutputFile(None, inFile)
+        modelOp = outputFile.addOperation(
+            operation_type=operation,
+            model=self.modelName,
+            modelPath=self.modelKey,
+            scale=scaleFactor,
+            masks=masks,
+        )
+
+        # Save the raw model output for strength/scale adjustment
+        if modelOp.supportsStrength():
+            outputFile.saveRawModelOutput(output, modelOp)
+            # Apply strength blending against the input image
+            inputImg = cv2.imread(inFile.path, cv2.IMREAD_UNCHANGED)
+            output = outputFile.applyStrengthBlending(output, modelOp, inputImg)
+
+        # Apply scaling if needed
+        output = outputFile.applyScale(output, modelOp)
+        outputFile.saveImageToCache(output)
+
+        return outputFile
+
+    def runOnExisting(
+        self,
+        outputFile: OutputFile,
+        operation: Operation = Operation.Sharpen,
+        masks: List[Mask] = None,
+    ):
+        """Run model on an existing OutputFile and update it in place"""
+        model = ModelLoader().load_from_file(self.modelPath)
+        assert isinstance(model, ImageModelDescriptor)
+
+        # Combine masks if provided
+        combinedMask = combine_masks(masks) if masks else None
+
+        processor = TileProcessor(
+            model=model,
+            tileSize=self.tileSize,
+            tilePad=self.tilePadding,
+            scale=model.scale,
+            device=self.device,
+            observer=self,
+            mask=combinedMask,
+        )
+
+        imgPath = outputFile.path
+        img = cv2.imread(imgPath, cv2.IMREAD_UNCHANGED)
+        output = processor.process_image(img)
+        if output is None:
+            return None
+
+        # Determine scale factor if maintaining original dimensions
+        scaleFactor = None
+        if self.maintainScale and model.scale > 1:
+            scaleFactor = 1 / model.scale
+
+        # Store the input path before adding operation (for strength blending)
+        inputPath = outputFile.path
+
+        # Add the operation to the existing file's operations list
+        outputFile.addOperation(
+            operation_type=operation,
+            model=self.modelName,
+            modelPath=self.modelKey,
+            scale=scaleFactor,
+            masks=masks,
+        )
+
+        # Get the operation we just added
+        modelOp = outputFile.operations[-1]
+
+        # Save the raw model output for strength/scale adjustment
+        if modelOp.supportsStrength():
+            outputFile.saveRawModelOutput(output, modelOp)
+            # Apply strength blending against the previous output (result of prior operations)
+            inputImg = cv2.imread(inputPath, cv2.IMREAD_UNCHANGED)
+            output = outputFile.applyStrengthBlending(output, modelOp, inputImg)
+
+        # Apply scaling if needed
+        output = outputFile.applyScale(output, modelOp)
+
+        # Save the (possibly blended/scaled) model output to cache
+        outputFile.saveImageToCache(output)
 
         return outputFile

--- a/src/enhance/op/model_runner.py
+++ b/src/enhance/op/model_runner.py
@@ -119,9 +119,11 @@ class ModelRunner(Observable):
             masks=masks,
         )
 
-        # Save the raw model output for strength/scale adjustment
+        # Save the raw model output for chain rebuilding
+        outputFile.saveRawModelOutput(output, modelOp)
+
+        # Apply strength blending if supported
         if modelOp.supportsStrength():
-            outputFile.saveRawModelOutput(output, modelOp)
             # Apply strength blending against the input image
             inputImg = cv2.imread(inFile.path, cv2.IMREAD_UNCHANGED)
             output = outputFile.applyStrengthBlending(output, modelOp, inputImg)
@@ -181,9 +183,11 @@ class ModelRunner(Observable):
         # Get the operation we just added
         modelOp = outputFile.operations[-1]
 
-        # Save the raw model output for strength/scale adjustment
+        # Save the raw model output for chain rebuilding
+        outputFile.saveRawModelOutput(output, modelOp)
+
+        # Apply strength blending if supported
         if modelOp.supportsStrength():
-            outputFile.saveRawModelOutput(output, modelOp)
             # Apply strength blending against the previous output (result of prior operations)
             inputImg = cv2.imread(inputPath, cv2.IMREAD_UNCHANGED)
             output = outputFile.applyStrengthBlending(output, modelOp, inputImg)

--- a/src/enhance/op/simple_tile_processor.py
+++ b/src/enhance/op/simple_tile_processor.py
@@ -38,6 +38,8 @@ class TileProcessor:
         # Combined mask (binary: 1 = process, 0 = skip)
         self.mask = mask
         self.mask_tensor = None
+        # Precomputed tile occupancy map (True = tile has mask pixels)
+        self.tile_occupancy = None
 
     def preprocess_img(self):
         # img size should be a multiple of tile size
@@ -62,6 +64,8 @@ class TileProcessor:
                 .to(self.device)
             )
             self.mask_tensor = F.pad(mask_t, (x1, x2, y1, y2), "constant", 0)
+            # Precompute tile occupancy map to avoid per-tile reductions
+            self._compute_tile_occupancy()
 
     def postprocess_result(self, img_tensor):
         # remove padding
@@ -135,20 +139,34 @@ class TileProcessor:
 
         return output_img
 
-    def _tile_has_mask_pixels(self, y: int, x: int) -> bool:
-        """Check if a tile contains any mask pixels (optimization to skip empty tiles)."""
+    def _compute_tile_occupancy(self):
+        """Precompute which tiles contain mask pixels (single device sync)."""
         if self.mask_tensor is None:
-            return True  # No mask means process all tiles
+            return
 
         actual_tile_size = self.tileSize - (self.tilePad * 2)
-        y1 = y * actual_tile_size
-        y2 = (y + 1) * actual_tile_size
-        x1 = x * actual_tile_size
-        x2 = (x + 1) * actual_tile_size
+        _, _, h, w = self.mask_tensor.shape
+        xtiles = math.ceil(w / actual_tile_size)
+        ytiles = math.ceil(h / actual_tile_size)
 
-        # Get the mask region for this tile (without padding)
-        mask_region = self.mask_tensor[:, :, y1:y2, x1:x2]
-        return mask_region.sum() > 0
+        # Build occupancy grid on device, then transfer once
+        occupancy = torch.zeros((ytiles, xtiles), dtype=torch.bool, device=self.device)
+        for y in range(ytiles):
+            for x in range(xtiles):
+                y1 = y * actual_tile_size
+                y2 = min((y + 1) * actual_tile_size, h)
+                x1 = x * actual_tile_size
+                x2 = min((x + 1) * actual_tile_size, w)
+                occupancy[y, x] = (self.mask_tensor[:, :, y1:y2, x1:x2] > 0).any()
+
+        # Single device sync: transfer to CPU
+        self.tile_occupancy = occupancy.cpu().numpy()
+
+    def _tile_has_mask_pixels(self, y: int, x: int) -> bool:
+        """Check if a tile contains any mask pixels using precomputed occupancy map."""
+        if self.tile_occupancy is None:
+            return True  # No mask means process all tiles
+        return bool(self.tile_occupancy[y, x])
 
     @torch.no_grad()
     def process_tiles(self):

--- a/src/enhance/ui/canvasLabel.py
+++ b/src/enhance/ui/canvasLabel.py
@@ -49,7 +49,7 @@ class CanvasLabel(QLabel):
         self.img4 = None
         self.fraction = 0.5
         self.renderMode: RenderMode = RenderMode.Single
-        self.renderMasks: bool = False
+        self.visibleMaskIndices: set = set()
 
         self.setScaledContents(False)
         self.setStatusMessage()
@@ -69,13 +69,15 @@ class CanvasLabel(QLabel):
         baseFile = self.selectionManager.getBaseFile()
         if baseFile is not None:
             self.img1 = cv2.imread(baseFile.path)
-            if self.renderMasks:
+            if self.visibleMaskIndices:
                 self.img1 = self.applyMasks(baseFile, self.img1)
 
             if self.renderMode == RenderMode.Split or self.renderMode == RenderMode.Grid:
                 compareFile = self.selectionManager.getCompareFile(0)
                 if compareFile is not None:
                     self.img2 = cv2.imread(compareFile.path)
+                    if self.visibleMaskIndices:
+                        self.img2 = self.applyMasks(baseFile, self.img2)
                 else:
                     self.img2 = np.zeros((self.img1.shape[0], self.img1.shape[1], 3), np.uint8)
 
@@ -83,12 +85,16 @@ class CanvasLabel(QLabel):
                 compareFile2 = self.selectionManager.getCompareFile(1)
                 if compareFile2 is not None:
                     self.img3 = cv2.imread(compareFile2.path)
+                    if self.visibleMaskIndices:
+                        self.img3 = self.applyMasks(baseFile, self.img3)
                 else:
                     self.img3 = np.zeros((self.img1.shape[0], self.img1.shape[1], 3), np.uint8)
 
                 compareFile3 = self.selectionManager.getCompareFile(2)
                 if compareFile3 is not None:
                     self.img4 = cv2.imread(compareFile3.path)
+                    if self.visibleMaskIndices:
+                        self.img4 = self.applyMasks(baseFile, self.img4)
                 else:
                     self.img4 = np.zeros((self.img1.shape[0], self.img1.shape[1], 3), np.uint8)
 
@@ -104,13 +110,15 @@ class CanvasLabel(QLabel):
     def applyMasks(self, file, img):
         if len(file.masks) > 0:
             for idx, mask in enumerate(file.masks):
+                if idx not in self.visibleMaskIndices:
+                    continue
                 # If there are masks, we can use the first one to set the size of the image
                 box = mask.box
-                color = MASK_COLORS[idx % len(MASK_COLORS)]
+                color = MASK_COLORS[idx % len(MASK_COLORS)].copy()
                 color.reverse()
                 img = cv2.rectangle(img, (int(box[0]), int(
                     box[1])), (int(box[2]), int(box[3])), color, 2)
-                img = cv2.putText(img, mask.label,
+                img = cv2.putText(img, mask.uniqueLabel,
                                   (int(box[0]), int(box[1]) - 10), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
                 mask_img = mask.mask
                 if mask_img is not None and len(mask_img.shape) == 2:
@@ -185,8 +193,8 @@ class CanvasLabel(QLabel):
         self.repaint()
         self.signals.changeZoom.emit(self.zoomFactor)
 
-    def setShowMasks(self, showMasks: bool) -> None:
-        self.renderMasks = showMasks
+    def setVisibleMasks(self, indices: set) -> None:
+        self.visibleMaskIndices = indices
         self.showFiles(False)
         self.repaint()
 

--- a/src/enhance/ui/dialog_model.ui
+++ b/src/enhance/ui/dialog_model.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>1098</width>
-    <height>500</height>
+    <height>608</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>400</height>
+    <height>480</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -71,7 +71,7 @@
             <string/>
            </property>
            <property name="pixmap">
-            <pixmap resource="icons.qrc">:/icons32/alert-circle.svg</pixmap>
+            <pixmap>:/icons32/alert-circle.svg</pixmap>
            </property>
           </widget>
          </item>
@@ -114,15 +114,18 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0">
-       <widget class="QFrame" name="frame_4">
+      <item row="5" column="0">
+       <widget class="QFrame" name="frame_masks">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
          <enum>QFrame::Plain</enum>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <property name="spacing">
+          <number>0</number>
+         </property>
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -136,7 +139,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="label_masks">
            <property name="minimumSize">
             <size>
              <width>100</width>
@@ -150,12 +153,90 @@
             </size>
            </property>
            <property name="text">
-            <string>Tile Size:</string>
+            <string>Apply to:</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="QFrame" name="frame_masksSelect">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_invertMask">
+            <property name="leftMargin">
+             <number>12</number>
+            </property>
+            <property name="topMargin">
+             <number>6</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_placeholder">
+              <property name="text">
+               <string>Placeholder</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QFrame" name="frame_8">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_5">
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="tileSize_combobox"/>
+          <widget class="QCheckBox" name="checkBox_maintainScale">
+           <property name="text">
+            <string>Maintain Original Scale</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -252,15 +333,15 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QFrame" name="frame_8">
+      <item row="3" column="0">
+       <widget class="QFrame" name="frame_4">
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -274,7 +355,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_5">
+          <widget class="QLabel" name="label_3">
            <property name="minimumSize">
             <size>
              <width>100</width>
@@ -288,16 +369,12 @@
             </size>
            </property>
            <property name="text">
-            <string/>
+            <string>Tile Size:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="checkBox_maintainScale">
-           <property name="text">
-            <string>Maintain Original Scale</string>
-           </property>
-          </widget>
+          <widget class="QComboBox" name="tileSize_combobox"/>
          </item>
         </layout>
        </widget>
@@ -353,7 +430,7 @@
             <string>Add and Manage Models</string>
            </property>
            <property name="icon">
-            <iconset resource="icons.qrc">
+            <iconset>
              <normaloff>:/icons32/plus-circle.svg</normaloff>:/icons32/plus-circle.svg</iconset>
            </property>
            <property name="iconSize">

--- a/src/enhance/ui/filestrip.py
+++ b/src/enhance/ui/filestrip.py
@@ -81,7 +81,10 @@ class FileStrip:
         self.addButton = QPushButton("+")
         self.addButton.setObjectName("addOutputFileButton")
         self.addButton.setFixedSize(QSize(FILE_BUTTON_SIZE, FILE_BUTTON_SIZE))
-        self.addButton.setStyleSheet("font-size: 32px; font-weight: bold;")
+        self.addButton.setStyleSheet(
+            "QPushButton { font-size: 48px; font-weight: bold; padding-bottom: 8px; }"
+            " QToolTip { font-size: 12px; font-weight: normal; }"
+        )
         self.addButton.setToolTip("Create new output file from current base")
         self.addButton.clicked.connect(lambda: self.signals.createOutputFile.emit())
         return self.addButton
@@ -91,7 +94,7 @@ class FileStrip:
             child.setParent(None)
             child.deleteLater()
         for child in frame.findChildren(QPushButton):
-            # Preserve the add button
+            # Preserve the add button; it will be repositioned by ensureAddButtonAtEnd
             if child == self.addButton:
                 continue
             child.setParent(None)
@@ -108,15 +111,18 @@ class FileStrip:
         self.ensureAddButtonAtEnd()
 
     def ensureAddButtonAtEnd(self):
-        """Ensure the '+' button is at the end of the file list"""
+        """Ensure the '+' button is the last item inside the file list."""
         if self.app.getBaseFile() is None:
-            return  # No base file, don't show add button
+            if self.addButton is not None:
+                self.addButton.setVisible(False)
+            return
         addBtn = self.makeAddButton()
-        # Remove from layout if present, then re-add at end
         layout = self.frameFileList.layout()
-        if addBtn.parent() == self.frameFileList:
-            layout.removeWidget(addBtn)
+        # Remove from current position if already in the layout
+        layout.removeWidget(addBtn)
+        # Re-add at the end
         layout.addWidget(addBtn, 0, Qt.AlignTop)
+        addBtn.setVisible(True)
 
     def drawFileList(self, focusOnFile: File = None):
         self.cleanFrame(self.frameBaseFile)
@@ -158,11 +164,21 @@ class FileStrip:
             self.scroll.ensureWidgetVisible(self.buttons[file])
 
     def addFileButton(self, frame: QFrame, button: QPushButton, forceFocus=False):
-        frame.layout().addWidget(button, 0, Qt.AlignTop)
+        layout = frame.layout()
+
+        # Insert before the "+" button if it exists in this frame
+        if frame == self.frameFileList and self.addButton is not None and self.addButton.parent() == frame:
+            idx = layout.indexOf(self.addButton)
+            if idx >= 0:
+                layout.insertWidget(idx, button, 0, Qt.AlignTop)
+            else:
+                layout.addWidget(button, 0, Qt.AlignTop)
+        else:
+            layout.addWidget(button, 0, Qt.AlignTop)
 
         # force frame relayout to adjust to content
-        frame.layout().invalidate()
-        frame.layout().activate()
+        layout.invalidate()
+        layout.activate()
         frame.updateGeometry()
 
     def updateThumbnails(self, frame, _=None):

--- a/src/enhance/ui/interface.ui
+++ b/src/enhance/ui/interface.ui
@@ -1306,7 +1306,7 @@ margin-top:5px;
 }</string>
             </property>
             <property name="title">
-             <string>Post Processing</string>
+             <string>Operations</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_20">
              <property name="leftMargin">

--- a/src/enhance/ui/interface.ui
+++ b/src/enhance/ui/interface.ui
@@ -225,7 +225,7 @@
                    <string/>
                   </property>
                   <property name="icon">
-                   <iconset>
+                   <iconset resource="icons.qrc">
                     <normaloff>:/icons32/chevron-down.svg</normaloff>:/icons32/chevron-down.svg</iconset>
                   </property>
                   <property name="iconSize">
@@ -262,7 +262,7 @@
                 <string/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="icons.qrc">
                  <normaloff>:/icons32/x.svg</normaloff>:/icons32/x.svg</iconset>
                </property>
                <property name="iconSize">
@@ -304,7 +304,7 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="icons.qrc">
               <normaloff>:/icons32/square.svg</normaloff>:/icons32/square.svg</iconset>
             </property>
             <property name="iconSize">
@@ -327,7 +327,7 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="icons.qrc">
               <normaloff>:/icons32/columns.svg</normaloff>:/icons32/columns.svg</iconset>
             </property>
             <property name="iconSize">
@@ -350,7 +350,7 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="icons.qrc">
               <normaloff>:/icons32/grid.svg</normaloff>:/icons32/grid.svg</iconset>
             </property>
             <property name="iconSize">
@@ -378,7 +378,7 @@
              <string>100%</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="icons.qrc">
               <normaloff>:/icons32/zoom-in.svg</normaloff>:/icons32/zoom-in.svg</iconset>
             </property>
             <property name="iconSize">
@@ -750,7 +750,7 @@
           </size>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::NoFrame</enum>
          </property>
          <property name="frameShadow">
           <enum>QFrame::Plain</enum>
@@ -796,23 +796,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton_run">
+           <widget class="QPushButton" name="pushButton_modelManager">
             <property name="text">
-             <string>Sharpen</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButton_denoise">
-            <property name="text">
-             <string>Denoise</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButton_upscale">
-            <property name="text">
-             <string>Upscale</string>
+             <string>Model Manager</string>
             </property>
            </widget>
           </item>
@@ -830,182 +816,143 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton_modelManager">
-            <property name="text">
-             <string>Model Manager</string>
+           <widget class="QFrame" name="frame_label_info">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
             </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QVBoxLayout" name="layout_label_info">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>12</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="label_7">
+               <property name="font">
+                <font>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>IMAGE INFO</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
-           <widget class="Line" name="line_3">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(92, 92, 92);</string>
+           <widget class="QFrame" name="frame_info_base">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
              <enum>QFrame::Plain</enum>
             </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="group_base">
-            <property name="styleSheet">
-             <string notr="true">QGroupBox {
-border: 1px solid rgb(92, 92, 92);
-margin-top: 14px;
-padding-top:10px;
-}
-QGroupBox::title {
-subcontrol-origin: margin;
-subcontrol-position: top left;
-left: 8px;
-padding:0 5px;
-margin-top:5px;
-}</string>
-            </property>
-            <property name="title">
-             <string>Base File</string>
-            </property>
-            <property name="flat">
-             <bool>false</bool>
-            </property>
-            <property name="checkable">
-             <bool>false</bool>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_18">
-             <property name="spacing">
-              <number>6</number>
-             </property>
+            <layout class="QVBoxLayout" name="verticalLayout_11">
              <property name="leftMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="topMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="bottomMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <item>
               <widget class="QLabel" name="label_13">
                <property name="text">
-                <string>Filename:</string>
+                <string>Input file:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QFrame" name="frame_label_filename_base">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_13">
-                <property name="leftMargin">
-                 <number>12</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_filename_base">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="margin">
-                   <number>0</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_14">
+              <widget class="QLabel" name="label_filename_base">
                <property name="text">
-                <string>Shape:</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="margin">
+                <number>0</number>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QFrame" name="frame_label_shape_base">
+              <widget class="QFrame" name="group_base">
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
                </property>
                <property name="frameShadow">
                 <enum>QFrame::Raised</enum>
                </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_14">
+               <layout class="QVBoxLayout" name="verticalLayout_18">
+                <property name="spacing">
+                 <number>6</number>
+                </property>
                 <property name="leftMargin">
                  <number>12</number>
                 </property>
                 <property name="topMargin">
-                 <number>0</number>
+                 <number>6</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>6</number>
                 </property>
                 <property name="bottomMargin">
-                 <number>0</number>
+                 <number>6</number>
                 </property>
                 <item>
-                 <widget class="QLabel" name="label_shape_base">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame_subject">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_5">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_4">
-                  <property name="text">
-                   <string>Subjects:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QFrame" name="frame_label_subjects">
+                 <widget class="QFrame" name="frame_label_filename_base">
                   <property name="frameShape">
                    <enum>QFrame::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Raised</enum>
                   </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_16">
+                  <layout class="QHBoxLayout" name="horizontalLayout_13">
+                   <property name="leftMargin">
+                    <number>12</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_14">
+                  <property name="text">
+                   <string>Shape:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame_label_shape_base">
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Raised</enum>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_14">
                    <property name="leftMargin">
                     <number>12</number>
                    </property>
@@ -1019,9 +966,201 @@ margin-top:5px;
                     <number>0</number>
                    </property>
                    <item>
-                    <widget class="QLabel" name="label_subjects">
+                    <widget class="QLabel" name="label_shape_base">
                      <property name="text">
-                      <string/>
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame_subject">
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Raised</enum>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QFrame" name="frame_label_subjects">
+                     <property name="frameShape">
+                      <enum>QFrame::NoFrame</enum>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Plain</enum>
+                     </property>
+                     <layout class="QHBoxLayout" name="horizontalLayout_16">
+                      <property name="leftMargin">
+                       <number>12</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>Subjects:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_subjects">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="frame_info_compare">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_12">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="label_8">
+               <property name="text">
+                <string>Enhanced File:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_filename">
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="margin">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QFrame" name="group_compare">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_19">
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <property name="leftMargin">
+                 <number>12</number>
+                </property>
+                <property name="topMargin">
+                 <number>6</number>
+                </property>
+                <property name="rightMargin">
+                 <number>6</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>6</number>
+                </property>
+                <item>
+                 <widget class="QFrame" name="frame_label_filename">
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Raised</enum>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <property name="leftMargin">
+                    <number>12</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_9">
+                  <property name="text">
+                   <string>Shape:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame_label_shape">
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Raised</enum>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_13">
+                   <property name="leftMargin">
+                    <number>12</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_shape">
+                     <property name="text">
+                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
@@ -1029,6 +1168,42 @@ margin-top:5px;
                  </widget>
                 </item>
                </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="frame_label_selection">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
+            </property>
+            <layout class="QVBoxLayout" name="layout_label_selection">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>12</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="label_10">
+               <property name="font">
+                <font>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>SELECTION</string>
+               </property>
               </widget>
              </item>
             </layout>
@@ -1063,10 +1238,27 @@ margin-top:5px;
               </widget>
              </item>
              <item>
-              <widget class="QCheckBox" name="checkBox_render_masks">
-               <property name="text">
-                <string>Render Masks</string>
+              <widget class="QFrame" name="frame_mask_visibility">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
                </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+               <layout class="QVBoxLayout" name="layout_mask_visibility">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+               </layout>
               </widget>
              </item>
             </layout>
@@ -1097,324 +1289,62 @@ margin-top:5px;
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="group_compare">
-            <property name="styleSheet">
-             <string notr="true">QGroupBox {
-border: 1px solid rgb(92, 92, 92);
-margin-top: 14px;
-padding-top:10px;
-}
-QGroupBox::title {
-subcontrol-origin: margin;
-subcontrol-position: top left;
-left: 8px;
-padding:0 5px;
-margin-top:5px;
-}</string>
+           <widget class="QFrame" name="frame_label_operations">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
             </property>
-            <property name="title">
-             <string>Compare File</string>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_19">
-             <property name="spacing">
-              <number>6</number>
-             </property>
+            <layout class="QVBoxLayout" name="layout_label_operations">
              <property name="leftMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="topMargin">
-              <number>6</number>
+              <number>12</number>
              </property>
              <property name="rightMargin">
-              <number>9</number>
+              <number>0</number>
              </property>
              <property name="bottomMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <item>
-              <widget class="QLabel" name="label_8">
+              <widget class="QLabel" name="label_11">
+               <property name="font">
+                <font>
+                 <bold>true</bold>
+                </font>
+               </property>
                <property name="text">
-                <string>Filename:</string>
+                <string>OPERATIONS</string>
                </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame_label_filename">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_10">
-                <property name="leftMargin">
-                 <number>12</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_filename">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="margin">
-                   <number>0</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>Operation:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame_label_opname">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_11">
-                <property name="leftMargin">
-                 <number>12</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_opname">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Model:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame_label_modelname">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_12">
-                <property name="leftMargin">
-                 <number>12</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_modelname">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#9a9996;&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_9">
-               <property name="text">
-                <string>Shape:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QFrame" name="frame_label_shape">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_13">
-                <property name="leftMargin">
-                 <number>12</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_shape">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p/&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
               </widget>
              </item>
             </layout>
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="group_postprocess">
-            <property name="styleSheet">
-             <string notr="true">QGroupBox {
-border: 1px solid rgb(92, 92, 92);
-margin-top: 14px;
-padding-top:10px;
-}
-QGroupBox::title {
-subcontrol-origin: margin;
-subcontrol-position: top left;
-left: 8px;
-padding:0 5px;
-margin-top:5px;
-}</string>
+           <widget class="QFrame" name="group_postprocess">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
             </property>
-            <property name="title">
-             <string>Operations</string>
+            <property name="frameShadow">
+             <enum>QFrame::Raised</enum>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_20">
              <property name="leftMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="topMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
              <property name="bottomMargin">
-              <number>6</number>
+              <number>0</number>
              </property>
-             <item>
-              <widget class="QFrame" name="frame_blur">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_7">
-                <property name="spacing">
-                 <number>6</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>9</number>
-                </property>
-                <item>
-                 <widget class="QLabel" name="label_6">
-                  <property name="text">
-                   <string>Blur:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QFrame" name="frame_7">
-                  <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
-                  </property>
-                  <property name="frameShadow">
-                   <enum>QFrame::Raised</enum>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_6">
-                   <property name="leftMargin">
-                    <number>12</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="label_blur_amt">
-                     <property name="minimumSize">
-                      <size>
-                       <width>30</width>
-                       <height>0</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string>0</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSlider" name="horizontalSlider_blur">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="tickPosition">
-                      <enum>QSlider::TicksBothSides</enum>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="Line" name="line_2">
-                  <property name="styleSheet">
-                   <string notr="true">color: rgb(92, 92, 92);</string>
-                  </property>
-                  <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
              <item>
               <widget class="QFrame" name="frame_scale">
                <property name="frameShape">
@@ -1604,6 +1534,27 @@ margin-top:5px;
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_run">
+            <property name="text">
+             <string>Sharpen</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_denoise">
+            <property name="text">
+             <string>Denoise</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_upscale">
+            <property name="text">
+             <string>Upscale</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/src/enhance/ui/interface.ui
+++ b/src/enhance/ui/interface.ui
@@ -729,10 +729,10 @@
          </layout>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QFrame" name="frame_sidebar">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -824,6 +824,9 @@
              <enum>QFrame::Raised</enum>
             </property>
             <layout class="QVBoxLayout" name="layout_label_info">
+             <property name="spacing">
+              <number>0</number>
+             </property>
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -845,6 +848,16 @@
                </property>
                <property name="text">
                 <string>IMAGE INFO</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line_9">
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -1182,6 +1195,9 @@
              <enum>QFrame::Raised</enum>
             </property>
             <layout class="QVBoxLayout" name="layout_label_selection">
+             <property name="spacing">
+              <number>0</number>
+             </property>
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -1203,6 +1219,16 @@
                </property>
                <property name="text">
                 <string>SELECTION</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line_7">
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -1297,6 +1323,9 @@
              <enum>QFrame::Raised</enum>
             </property>
             <layout class="QVBoxLayout" name="layout_label_operations">
+             <property name="spacing">
+              <number>0</number>
+             </property>
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -1318,6 +1347,16 @@
                </property>
                <property name="text">
                 <string>OPERATIONS</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line_3">
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -1511,25 +1550,70 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="Line" name="line_6">
-                  <property name="styleSheet">
-                   <string notr="true">color: rgb(92, 92, 92);</string>
-                  </property>
-                  <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                 <widget class="QPushButton" name="pushButton_postprocess_apply">
+                  <property name="text">
+                   <string>Apply</string>
                   </property>
                  </widget>
                 </item>
                </layout>
               </widget>
              </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="Line" name="line_6">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(92, 92, 92);</string>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="frame_11">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_17">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
-              <widget class="QPushButton" name="pushButton_postprocess_apply">
+              <widget class="QPushButton" name="pushButton_run">
                <property name="text">
-                <string>Apply</string>
+                <string>Sharpen</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_denoise">
+               <property name="text">
+                <string>Denoise</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_upscale">
+               <property name="text">
+                <string>Upscale</string>
                </property>
               </widget>
              </item>
@@ -1537,25 +1621,62 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton_run">
-            <property name="text">
-             <string>Sharpen</string>
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton_denoise">
+           <widget class="QFrame" name="frame_7">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_16">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="pushButton_saveFile">
+               <property name="text">
+                <string>Save File</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_delete">
             <property name="text">
-             <string>Denoise</string>
+             <string>Delete File</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="pushButton_upscale">
-            <property name="text">
-             <string>Upscale</string>
+           <spacer name="verticalSpacer_sidebar">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-           </widget>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/src/enhance/ui/mask_selector.py
+++ b/src/enhance/ui/mask_selector.py
@@ -1,0 +1,339 @@
+"""
+Custom mask selector widget with dropdown menu.
+Shows checkable masks with inside/outside selection per mask.
+"""
+from PySide6.QtWidgets import (
+    QToolButton,
+    QWidget,
+    QHBoxLayout,
+    QCheckBox,
+    QPushButton,
+    QLabel,
+    QFrame,
+    QVBoxLayout,
+    QButtonGroup,
+    QApplication,
+)
+from PySide6.QtCore import Signal, Qt, QPoint, QTimer
+
+from typing import List, Tuple
+from enhance.lib.file import Mask
+
+
+class ClickableLabel(QLabel):
+    """A QLabel that emits a signal when clicked."""
+    clicked = Signal()
+    
+    def mousePressEvent(self, event):
+        self.clicked.emit()
+        event.accept()  # Accept the event to prevent it from propagating
+
+
+class MaskItemWidget(QWidget):
+    """Widget for a single mask item in the dropdown menu."""
+    
+    changed = Signal()  # Emitted when checkbox or mode changes
+    
+    def __init__(self, mask: Mask, parent=None):
+        super().__init__(parent)
+        self.mask = mask
+        self._inverted = False
+        self.setupUi()
+    
+    def setupUi(self):
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setSpacing(8)
+        
+        # Checkbox for selecting the mask
+        self.checkbox = QCheckBox(self.mask.uniqueLabel)
+        self.checkbox.setStyleSheet("color: #ddd;")
+        self.checkbox.stateChanged.connect(self._onCheckboxChanged)
+        layout.addWidget(self.checkbox)
+        
+        layout.addStretch()
+        
+        # Clickable label that toggles between inside/outside
+        self.modeLabel = ClickableLabel("inside")
+        self.modeLabel.setFixedWidth(70)
+        self.modeLabel.setAlignment(Qt.AlignCenter)
+        self.modeLabel.setCursor(Qt.PointingHandCursor)
+        self.modeLabel.clicked.connect(self._toggleMode)
+        self._applyInsideStyle()
+        layout.addWidget(self.modeLabel)
+    
+    def _toggleMode(self):
+        """Toggle between inside and outside."""
+        if not self.checkbox.isChecked():
+            # Auto-check the checkbox when clicking mode
+            self.checkbox.setChecked(True)
+        self._inverted = not self._inverted
+        self._applyModeStyle()
+        self._onChanged()
+    
+    def _onCheckboxChanged(self, state):
+        self._applyModeStyle()
+        self._onChanged()
+    
+    def _applyModeStyle(self):
+        if self._inverted:
+            self._applyOutsideStyle()
+        else:
+            self._applyInsideStyle()
+    
+    def _applyInsideStyle(self):
+        self.modeLabel.setText("inside")
+        if self.checkbox.isChecked():
+            self.modeLabel.setStyleSheet("""
+                QLabel {
+                    color: #fff;
+                    padding: 2px 6px;
+                    border: 1px solid #5a9f5a;
+                    border-radius: 3px;
+                    background-color: #4a8f4a;
+                }
+            """)
+        else:
+            self.modeLabel.setStyleSheet("""
+                QLabel {
+                    color: #888;
+                    padding: 2px 6px;
+                    border: 1px solid #555;
+                    border-radius: 3px;
+                    background-color: #3a3a3a;
+                }
+            """)
+    
+    def _applyOutsideStyle(self):
+        self.modeLabel.setText("outside")
+        if self.checkbox.isChecked():
+            self.modeLabel.setStyleSheet("""
+                QLabel {
+                    color: #fff;
+                    padding: 2px 6px;
+                    border: 1px solid #5a7fb5;
+                    border-radius: 3px;
+                    background-color: #4a6fa5;
+                }
+            """)
+        else:
+            self.modeLabel.setStyleSheet("""
+                QLabel {
+                    color: #888;
+                    padding: 2px 6px;
+                    border: 1px solid #555;
+                    border-radius: 3px;
+                    background-color: #3a3a3a;
+                }
+            """)
+    
+    def _onChanged(self):
+        self.changed.emit()
+    
+    def isSelected(self) -> bool:
+        return self.checkbox.isChecked()
+    
+    def setSelected(self, selected: bool):
+        self.checkbox.setChecked(selected)
+        self._applyModeStyle()
+    
+    def isInverted(self) -> bool:
+        return self._inverted
+    
+    def setInverted(self, inverted: bool):
+        self._inverted = inverted
+        self._applyModeStyle()
+
+
+class MaskPopupFrame(QFrame):
+    """A popup frame containing mask selection widgets."""
+    
+    selectionChanged = Signal(list)
+    closed = Signal()
+    
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowFlags(Qt.Popup)
+        self.setFrameShape(QFrame.StyledPanel)
+        self.setStyleSheet("""
+            MaskPopupFrame {
+                background-color: #2d2d2d;
+                border: 1px solid #555;
+                border-radius: 4px;
+            }
+        """)
+        
+        self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(4, 4, 4, 4)
+        self.layout.setSpacing(2)
+        
+        self.maskWidgets: List[MaskItemWidget] = []
+        self._initialSelection = []
+    
+    def showEvent(self, event):
+        """Remember selection state when popup opens."""
+        super().showEvent(event)
+        self._initialSelection = self._getSelectionKey()
+    
+    def hideEvent(self, event):
+        """Emit signal when popup closes if selection changed."""
+        super().hideEvent(event)
+        currentSelection = self._getSelectionKey()
+        if currentSelection != self._initialSelection:
+            self.selectionChanged.emit(self.getSelection())
+        self.closed.emit()
+    
+    def _getSelectionKey(self) -> tuple:
+        """Get a hashable key representing the current selection state."""
+        return tuple((w.mask.uniqueLabel, w.isSelected(), w.isInverted()) for w in self.maskWidgets)
+    
+    def setMasks(self, masks: List[Mask], selectedMasks: List[Mask] = None):
+        """Set the available masks."""
+        # Clear existing widgets
+        for widget in self.maskWidgets:
+            widget.deleteLater()
+        self.maskWidgets.clear()
+        
+        # Clear layout
+        while self.layout.count():
+            item = self.layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        
+        # Build a dict of selected mask labels to their inverted state
+        selectedMaskInfo = {m.uniqueLabel: m.inverted for m in (selectedMasks or [])}
+        
+        for mask in masks:
+            itemWidget = MaskItemWidget(mask)
+            
+            # Pre-select if in selectedMasks and set inverted state
+            if mask.uniqueLabel in selectedMaskInfo:
+                itemWidget.setSelected(True)
+                itemWidget.setInverted(selectedMaskInfo[mask.uniqueLabel])
+            
+            self.layout.addWidget(itemWidget)
+            self.maskWidgets.append(itemWidget)
+        
+        self.adjustSize()
+    
+    def getSelection(self) -> List[Mask]:
+        """Get the current selection with per-mask inverted property set."""
+        selectedMasks = []
+        
+        for widget in self.maskWidgets:
+            if widget.isSelected():
+                # Set the inverted property on the mask
+                widget.mask.inverted = widget.isInverted()
+                selectedMasks.append(widget.mask)
+        
+        return selectedMasks
+
+
+class MaskSelectorButton(QToolButton):
+    """
+    A button that opens a dropdown menu for selecting masks.
+    Each mask can be toggled and set to inside/outside mode.
+    """
+    
+    selectionChanged = Signal(list)  # List of Mask objects with inverted property set
+    
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.masks: List[Mask] = []
+        self.popup: MaskPopupFrame = None
+        
+        self.setText("Masks: None")
+        self.setStyleSheet("""
+            QToolButton {
+                background-color: #3d3d3d;
+                color: #ddd;
+                border: 1px solid #555;
+                border-radius: 4px;
+                padding: 4px 12px;
+                text-align: left;
+            }
+            QToolButton:hover {
+                background-color: #4d4d4d;
+            }
+        """)
+        
+        self.clicked.connect(self._showPopup)
+    
+    def _showPopup(self):
+        """Show the popup with mask options."""
+        if not self.popup or not self.masks:
+            return
+        
+        # Position popup below the button
+        pos = self.mapToGlobal(QPoint(0, self.height()))
+        self.popup.move(pos)
+        self.popup.show()
+    
+    def setMasks(self, masks: List[Mask], selectedMasks: List[Mask] = None):
+        """Set the available masks and optionally pre-select some."""
+        self.masks = masks
+        
+        if not masks:
+            self.setText("Masks: None available")
+            self.setEnabled(False)
+            if self.popup:
+                self.popup.hide()
+            return
+        
+        self.setEnabled(True)
+        
+        # Create popup if needed
+        if self.popup is None:
+            self.popup = MaskPopupFrame()
+            self.popup.selectionChanged.connect(self._onPopupSelectionChanged)
+            self.popup.closed.connect(self._updateButtonText)
+        
+        self.popup.setMasks(masks, selectedMasks)
+        self._updateButtonText()
+    
+    def _onPopupSelectionChanged(self, selectedMasks: list):
+        """Handle selection changes from the popup."""
+        self.selectionChanged.emit(selectedMasks)
+    
+    def _updateButtonText(self):
+        """Update the button text to reflect current selection."""
+        if not self.popup:
+            return
+        
+        selected = [w for w in self.popup.maskWidgets if w.isSelected()]
+        
+        if not selected:
+            self.setText("Masks: None")
+        elif len(selected) == 1:
+            mode = "outside" if selected[0].isInverted() else "inside"
+            self.setText(f"Mask: {selected[0].mask.uniqueLabel} ({mode})")
+        else:
+            # Check if all have same mode
+            modes = set(w.isInverted() for w in selected)
+            if len(modes) == 1:
+                mode = "outside" if selected[0].isInverted() else "inside"
+                self.setText(f"Masks: {len(selected)} selected ({mode})")
+            else:
+                self.setText(f"Masks: {len(selected)} selected (mixed)")
+    
+    def getSelection(self) -> List[Mask]:
+        """Get the current selection."""
+        if self.popup:
+            return self.popup.getSelection()
+        return []
+    
+    def setSelection(self, selectedMasks: List[Mask]):
+        """Set the current selection programmatically."""
+        if self.popup:
+            # Build a dict of selected mask labels to their inverted state
+            selectedMaskInfo = {m.uniqueLabel: m.inverted for m in selectedMasks}
+            
+            for widget in self.popup.maskWidgets:
+                if widget.mask.uniqueLabel in selectedMaskInfo:
+                    widget.setSelected(True)
+                    widget.setInverted(selectedMaskInfo[widget.mask.uniqueLabel])
+                else:
+                    widget.setSelected(False)
+            
+            self._updateButtonText()
+

--- a/src/enhance/ui/mask_selector.py
+++ b/src/enhance/ui/mask_selector.py
@@ -1,30 +1,28 @@
 """
-Custom mask selector widget with dropdown menu.
+Mask selector widget with dropdown menu.
 Shows checkable masks with inside/outside selection per mask.
 """
+
 from PySide6.QtWidgets import (
     QToolButton,
     QWidget,
     QHBoxLayout,
     QCheckBox,
-    QPushButton,
     QLabel,
     QFrame,
     QVBoxLayout,
-    QButtonGroup,
-    QApplication,
 )
-from PySide6.QtCore import Signal, Qt, QPoint, QTimer
+from PySide6.QtCore import Signal, Qt, QPoint
 
 import copy
-from typing import List, Tuple
+from typing import List
 from enhance.lib.file import Mask
 
 
 class ClickableLabel(QLabel):
     """A QLabel that emits a signal when clicked."""
     clicked = Signal()
-    
+
     def mousePressEvent(self, event):
         self.clicked.emit()
         event.accept()  # Accept the event to prevent it from propagating
@@ -32,57 +30,57 @@ class ClickableLabel(QLabel):
 
 class MaskItemWidget(QWidget):
     """Widget for a single mask item in the dropdown menu."""
-    
+
     changed = Signal()  # Emitted when checkbox or mode changes
-    
+
     def __init__(self, mask: Mask, parent=None):
         super().__init__(parent)
         self.mask = mask
         self._inverted = False
         self.setupUi()
-    
+
     def setupUi(self):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
         layout.setSpacing(8)
-        
+
         # Checkbox for selecting the mask
         self.checkbox = QCheckBox(self.mask.uniqueLabel)
         self.checkbox.setStyleSheet("color: #ddd;")
-        self.checkbox.stateChanged.connect(self._onCheckboxChanged)
+        self.checkbox.stateChanged.connect(self._on_checkbox_changed)
         layout.addWidget(self.checkbox)
-        
+
         layout.addStretch()
-        
+
         # Clickable label that toggles between inside/outside
         self.modeLabel = ClickableLabel("inside")
         self.modeLabel.setFixedWidth(70)
         self.modeLabel.setAlignment(Qt.AlignCenter)
         self.modeLabel.setCursor(Qt.PointingHandCursor)
-        self.modeLabel.clicked.connect(self._toggleMode)
-        self._applyInsideStyle()
+        self.modeLabel.clicked.connect(self._toggle_mode)
+        self._apply_inside_style()
         layout.addWidget(self.modeLabel)
-    
-    def _toggleMode(self):
+
+    def _toggle_mode(self):
         """Toggle between inside and outside."""
         if not self.checkbox.isChecked():
             # Auto-check the checkbox when clicking mode
             self.checkbox.setChecked(True)
         self._inverted = not self._inverted
-        self._applyModeStyle()
-        self._onChanged()
-    
-    def _onCheckboxChanged(self, state):
-        self._applyModeStyle()
-        self._onChanged()
-    
-    def _applyModeStyle(self):
+        self._apply_mode_style()
+        self._on_changed()
+
+    def _on_checkbox_changed(self, state):
+        self._apply_mode_style()
+        self._on_changed()
+
+    def _apply_mode_style(self):
         if self._inverted:
-            self._applyOutsideStyle()
+            self._apply_outside_style()
         else:
-            self._applyInsideStyle()
-    
-    def _applyInsideStyle(self):
+            self._apply_inside_style()
+
+    def _apply_inside_style(self):
         self.modeLabel.setText("inside")
         if self.checkbox.isChecked():
             self.modeLabel.setStyleSheet("""
@@ -104,8 +102,8 @@ class MaskItemWidget(QWidget):
                     background-color: #3a3a3a;
                 }
             """)
-    
-    def _applyOutsideStyle(self):
+
+    def _apply_outside_style(self):
         self.modeLabel.setText("outside")
         if self.checkbox.isChecked():
             self.modeLabel.setStyleSheet("""
@@ -127,31 +125,31 @@ class MaskItemWidget(QWidget):
                     background-color: #3a3a3a;
                 }
             """)
-    
-    def _onChanged(self):
+
+    def _on_changed(self):
         self.changed.emit()
-    
-    def isSelected(self) -> bool:
+
+    def is_selected(self) -> bool:
         return self.checkbox.isChecked()
-    
-    def setSelected(self, selected: bool):
+
+    def set_selected(self, selected: bool):
         self.checkbox.setChecked(selected)
-        self._applyModeStyle()
-    
-    def isInverted(self) -> bool:
+        self._apply_mode_style()
+
+    def is_inverted(self) -> bool:
         return self._inverted
-    
-    def setInverted(self, inverted: bool):
+
+    def set_inverted(self, inverted: bool):
         self._inverted = inverted
-        self._applyModeStyle()
+        self._apply_mode_style()
 
 
 class MaskPopupFrame(QFrame):
     """A popup frame containing mask selection widgets."""
-    
+
     selectionChanged = Signal(list)
     closed = Signal()
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowFlags(Qt.Popup)
@@ -163,71 +161,74 @@ class MaskPopupFrame(QFrame):
                 border-radius: 4px;
             }
         """)
-        
+
         self.layout = QVBoxLayout(self)
         self.layout.setContentsMargins(4, 4, 4, 4)
         self.layout.setSpacing(2)
-        
-        self.maskWidgets: List[MaskItemWidget] = []
+
+        self.mask_widgets: List[MaskItemWidget] = []
         self._initialSelection = []
-    
+
     def showEvent(self, event):
         """Remember selection state when popup opens."""
         super().showEvent(event)
-        self._initialSelection = self._getSelectionKey()
-    
+        self._initialSelection = self._get_selection_key()
+
     def hideEvent(self, event):
         """Emit signal when popup closes if selection changed."""
         super().hideEvent(event)
-        currentSelection = self._getSelectionKey()
-        if currentSelection != self._initialSelection:
-            self.selectionChanged.emit(self.getSelection())
+        current_selection = self._get_selection_key()
+        if current_selection != self._initialSelection:
+            self.selectionChanged.emit(self.get_selection())
         self.closed.emit()
-    
-    def _getSelectionKey(self) -> tuple:
+
+    def _get_selection_key(self) -> tuple:
         """Get a hashable key representing the current selection state."""
-        return tuple((w.mask.uniqueLabel, w.isSelected(), w.isInverted()) for w in self.maskWidgets)
-    
-    def setMasks(self, masks: List[Mask], selectedMasks: List[Mask] = None):
+        return tuple(
+            (w.mask.uniqueLabel, w.is_selected(), w.is_inverted())
+            for w in self.mask_widgets
+        )
+
+    def set_masks(self, masks: List[Mask], selected_masks: List[Mask] = None):
         """Set the available masks."""
         # Clear existing widgets
-        for widget in self.maskWidgets:
+        for widget in self.mask_widgets:
             widget.deleteLater()
-        self.maskWidgets.clear()
-        
+        self.mask_widgets.clear()
+
         # Clear layout
         while self.layout.count():
             item = self.layout.takeAt(0)
             if item.widget():
                 item.widget().deleteLater()
-        
+
         # Build a dict of selected mask labels to their inverted state
-        selectedMaskInfo = {m.uniqueLabel: m.inverted for m in (selectedMasks or [])}
-        
+        selected_mask_info = {m.uniqueLabel: m.inverted for m in (selected_masks or [])}
+
         for mask in masks:
-            itemWidget = MaskItemWidget(mask)
-            
-            # Pre-select if in selectedMasks and set inverted state
-            if mask.uniqueLabel in selectedMaskInfo:
-                itemWidget.setSelected(True)
-                itemWidget.setInverted(selectedMaskInfo[mask.uniqueLabel])
-            
-            self.layout.addWidget(itemWidget)
-            self.maskWidgets.append(itemWidget)
-        
+            item_widget = MaskItemWidget(mask)
+
+            # Pre-select if in selected_masks and set inverted state
+            if mask.uniqueLabel in selected_mask_info:
+                item_widget.set_selected(True)
+                item_widget.set_inverted(selected_mask_info[mask.uniqueLabel])
+
+            self.layout.addWidget(item_widget)
+            self.mask_widgets.append(item_widget)
+
         self.adjustSize()
-    
-    def getSelection(self) -> List[Mask]:
+
+    def get_selection(self) -> List[Mask]:
         """Get the current selection with per-mask inverted property set."""
-        selectedMasks = []
-        
-        for widget in self.maskWidgets:
-            if widget.isSelected():
-                maskCopy = copy.copy(widget.mask)
-                maskCopy.inverted = widget.isInverted()
-                selectedMasks.append(maskCopy)
-        
-        return selectedMasks
+        selected_masks = []
+
+        for widget in self.mask_widgets:
+            if widget.is_selected():
+                mask_copy = copy.copy(widget.mask)
+                mask_copy.inverted = widget.is_inverted()
+                selected_masks.append(mask_copy)
+
+        return selected_masks
 
 
 class MaskSelectorButton(QToolButton):
@@ -235,14 +236,14 @@ class MaskSelectorButton(QToolButton):
     A button that opens a dropdown menu for selecting masks.
     Each mask can be toggled and set to inside/outside mode.
     """
-    
-    selectionChanged = Signal(list)  # List of Mask objects with inverted property set
-    
+
+    selectionChanged = Signal(list)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.masks: List[Mask] = []
         self.popup: MaskPopupFrame = None
-        
+
         self.setText("Masks: None")
         self.setStyleSheet("""
             QToolButton {
@@ -257,84 +258,83 @@ class MaskSelectorButton(QToolButton):
                 background-color: #4d4d4d;
             }
         """)
-        
-        self.clicked.connect(self._showPopup)
-    
-    def _showPopup(self):
+
+        self.clicked.connect(self._show_popup)
+
+    def _show_popup(self):
         """Show the popup with mask options."""
         if not self.popup or not self.masks:
             return
-        
+
         # Position popup below the button
         pos = self.mapToGlobal(QPoint(0, self.height()))
         self.popup.move(pos)
         self.popup.show()
-    
-    def setMasks(self, masks: List[Mask], selectedMasks: List[Mask] = None):
+
+    def set_masks(self, masks: List[Mask], selected_masks: List[Mask] = None):
         """Set the available masks and optionally pre-select some."""
         self.masks = masks
-        
+
         if not masks:
             self.setText("Masks: None available")
             self.setEnabled(False)
             if self.popup:
                 self.popup.hide()
             return
-        
+
         self.setEnabled(True)
-        
+
         # Create popup if needed
         if self.popup is None:
             self.popup = MaskPopupFrame()
-            self.popup.selectionChanged.connect(self._onPopupSelectionChanged)
-            self.popup.closed.connect(self._updateButtonText)
-        
-        self.popup.setMasks(masks, selectedMasks)
-        self._updateButtonText()
-    
-    def _onPopupSelectionChanged(self, selectedMasks: list):
+            self.popup.selectionChanged.connect(self._on_popup_selection_changed)
+            self.popup.closed.connect(self._update_button_text)
+
+        self.popup.set_masks(masks, selected_masks)
+        self._update_button_text()
+
+    def _on_popup_selection_changed(self, selected_masks: list):
         """Handle selection changes from the popup."""
-        self.selectionChanged.emit(selectedMasks)
-    
-    def _updateButtonText(self):
+        self.selectionChanged.emit(selected_masks)
+
+    def _update_button_text(self):
         """Update the button text to reflect current selection."""
         if not self.popup:
             return
-        
-        selected = [w for w in self.popup.maskWidgets if w.isSelected()]
-        
+
+        selected = [w for w in self.popup.mask_widgets if w.is_selected()]
+
         if not selected:
             self.setText("Masks: None")
         elif len(selected) == 1:
-            mode = "outside" if selected[0].isInverted() else "inside"
+            mode = "outside" if selected[0].is_inverted() else "inside"
             self.setText(f"Mask: {selected[0].mask.uniqueLabel} ({mode})")
         else:
             # Check if all have same mode
-            modes = set(w.isInverted() for w in selected)
+            modes = set(w.is_inverted() for w in selected)
             if len(modes) == 1:
-                mode = "outside" if selected[0].isInverted() else "inside"
+                mode = "outside" if selected[0].is_inverted() else "inside"
                 self.setText(f"Masks: {len(selected)} selected ({mode})")
             else:
                 self.setText(f"Masks: {len(selected)} selected (mixed)")
-    
-    def getSelection(self) -> List[Mask]:
+
+    def get_selection(self) -> List[Mask]:
         """Get the current selection."""
         if self.popup:
-            return self.popup.getSelection()
+            return self.popup.get_selection()
         return []
-    
-    def setSelection(self, selectedMasks: List[Mask]):
+
+    def set_selection(self, selected_masks: List[Mask]):
         """Set the current selection programmatically."""
         if self.popup:
             # Build a dict of selected mask labels to their inverted state
-            selectedMaskInfo = {m.uniqueLabel: m.inverted for m in selectedMasks}
-            
-            for widget in self.popup.maskWidgets:
-                if widget.mask.uniqueLabel in selectedMaskInfo:
-                    widget.setSelected(True)
-                    widget.setInverted(selectedMaskInfo[widget.mask.uniqueLabel])
-                else:
-                    widget.setSelected(False)
-            
-            self._updateButtonText()
+            selected_mask_info = {m.uniqueLabel: m.inverted for m in selected_masks}
 
+            for widget in self.popup.mask_widgets:
+                if widget.mask.uniqueLabel in selected_mask_info:
+                    widget.set_selected(True)
+                    widget.set_inverted(selected_mask_info[widget.mask.uniqueLabel])
+                else:
+                    widget.set_selected(False)
+
+            self._update_button_text()

--- a/src/enhance/ui/mask_selector.py
+++ b/src/enhance/ui/mask_selector.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Signal, Qt, QPoint, QTimer
 
+import copy
 from typing import List, Tuple
 from enhance.lib.file import Mask
 
@@ -222,9 +223,9 @@ class MaskPopupFrame(QFrame):
         
         for widget in self.maskWidgets:
             if widget.isSelected():
-                # Set the inverted property on the mask
-                widget.mask.inverted = widget.isInverted()
-                selectedMasks.append(widget.mask)
+                maskCopy = copy.copy(widget.mask)
+                maskCopy.inverted = widget.isInverted()
+                selectedMasks.append(maskCopy)
         
         return selectedMasks
 

--- a/src/enhance/ui/mask_visibility_list.py
+++ b/src/enhance/ui/mask_visibility_list.py
@@ -1,0 +1,71 @@
+from PySide6.QtWidgets import (
+    QFrame,
+    QVBoxLayout,
+    QCheckBox,
+    QLabel,
+)
+from PySide6.QtCore import Signal
+from typing import List
+
+from enhance.lib.file import Mask
+
+
+class MaskVisibilityList(QFrame):
+    """A widget that displays a list of masks with checkboxes to toggle visibility."""
+
+    visibilityChanged = Signal(set)  # Emits the set of visible mask indices
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.masks: List[Mask] = []
+        self.checkboxes: List[QCheckBox] = []
+        self.setupUi()
+
+    def setupUi(self):
+        self.setFrameShape(QFrame.NoFrame)
+        self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout.setSpacing(2)
+
+    def setMasks(self, masks: List[Mask]):
+        """Update the list of masks displayed."""
+        # Clear existing checkboxes
+        for checkbox in self.checkboxes:
+            self.layout.removeWidget(checkbox)
+            checkbox.deleteLater()
+        self.checkboxes.clear()
+
+        self.masks = masks if masks else []
+
+        # Create checkboxes for each mask
+        for idx, mask in enumerate(self.masks):
+            checkbox = QCheckBox(mask.uniqueLabel)
+            checkbox.setStyleSheet("color: #aaa;")
+            checkbox.setChecked(False)
+            checkbox.stateChanged.connect(self._onCheckboxChanged)
+            self.checkboxes.append(checkbox)
+            self.layout.addWidget(checkbox)
+
+    def _onCheckboxChanged(self):
+        """Handle checkbox state changes."""
+        visible = set()
+        for idx, checkbox in enumerate(self.checkboxes):
+            if checkbox.isChecked():
+                visible.add(idx)
+        self.visibilityChanged.emit(visible)
+
+    def getVisibleIndices(self) -> set:
+        """Get the set of currently visible mask indices."""
+        visible = set()
+        for idx, checkbox in enumerate(self.checkboxes):
+            if checkbox.isChecked():
+                visible.add(idx)
+        return visible
+
+    def setAllVisible(self, visible: bool):
+        """Set all masks visible or hidden."""
+        for checkbox in self.checkboxes:
+            checkbox.blockSignals(True)
+            checkbox.setChecked(visible)
+            checkbox.blockSignals(False)
+        self._onCheckboxChanged()

--- a/src/enhance/ui/mask_visibility_list.py
+++ b/src/enhance/ui/mask_visibility_list.py
@@ -2,7 +2,6 @@ from PySide6.QtWidgets import (
     QFrame,
     QVBoxLayout,
     QCheckBox,
-    QLabel,
 )
 from PySide6.QtCore import Signal
 from typing import List
@@ -27,7 +26,7 @@ class MaskVisibilityList(QFrame):
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layout.setSpacing(2)
 
-    def setMasks(self, masks: List[Mask]):
+    def set_masks(self, masks: List[Mask]):
         """Update the list of masks displayed."""
         # Clear existing checkboxes
         for checkbox in self.checkboxes:
@@ -42,11 +41,11 @@ class MaskVisibilityList(QFrame):
             checkbox = QCheckBox(mask.uniqueLabel)
             checkbox.setStyleSheet("color: #aaa;")
             checkbox.setChecked(False)
-            checkbox.stateChanged.connect(self._onCheckboxChanged)
+            checkbox.stateChanged.connect(self._on_checkbox_changed)
             self.checkboxes.append(checkbox)
             self.layout.addWidget(checkbox)
 
-    def _onCheckboxChanged(self):
+    def _on_checkbox_changed(self):
         """Handle checkbox state changes."""
         visible = set()
         for idx, checkbox in enumerate(self.checkboxes):
@@ -54,7 +53,7 @@ class MaskVisibilityList(QFrame):
                 visible.add(idx)
         self.visibilityChanged.emit(visible)
 
-    def getVisibleIndices(self) -> set:
+    def get_visible_indices(self) -> set:
         """Get the set of currently visible mask indices."""
         visible = set()
         for idx, checkbox in enumerate(self.checkboxes):
@@ -62,10 +61,10 @@ class MaskVisibilityList(QFrame):
                 visible.add(idx)
         return visible
 
-    def setAllVisible(self, visible: bool):
+    def set_all_visible(self, visible: bool):
         """Set all masks visible or hidden."""
         for checkbox in self.checkboxes:
             checkbox.blockSignals(True)
             checkbox.setChecked(visible)
             checkbox.blockSignals(False)
-        self._onCheckboxChanged()
+        self._on_checkbox_changed()

--- a/src/enhance/ui/operation_widget.py
+++ b/src/enhance/ui/operation_widget.py
@@ -1,0 +1,181 @@
+from PySide6.QtWidgets import (
+    QFrame,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QSlider,
+)
+from PySide6.QtCore import Qt, Signal
+
+from enhance.lib.file import AppliedOperation, Mask
+from enhance.ui.mask_selector import MaskSelectorButton
+from typing import List
+
+
+class OperationWidget(QFrame):
+    """A widget that displays a single operation with its controls."""
+
+    strengthChanged = Signal(AppliedOperation, float)
+    masksChanged = Signal(AppliedOperation, list)
+
+    def __init__(self, operation: AppliedOperation, availableMasks: List[Mask] = None, parent=None):
+        super().__init__(parent)
+        self.operation = operation
+        self.availableMasks = availableMasks if availableMasks else []
+        self.maskSelector: MaskSelectorButton = None
+        self.setupUi()
+
+    def setupUi(self):
+        self.setFrameShape(QFrame.NoFrame)
+        self.setStyleSheet("""
+            OperationWidget {
+                border: 1px solid rgb(92, 92, 92);
+                border-radius: 4px;
+                margin: 2px;
+                padding: 4px;
+            }
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(4)
+
+        # Operation name header
+        nameLabel = QLabel(self._getOperationDisplayName())
+        nameLabel.setStyleSheet("font-weight: bold; color: #fff;")
+        layout.addWidget(nameLabel)
+
+        # Model name (if applicable)
+        if self.operation.model:
+            modelFrame = QFrame()
+            modelFrame.setFrameShape(QFrame.NoFrame)
+            modelLayout = QHBoxLayout(modelFrame)
+            modelLayout.setContentsMargins(12, 0, 0, 0)
+            modelLayout.setSpacing(4)
+
+            modelLabel = QLabel(self.operation.model)
+            modelLabel.setStyleSheet("color: #9a9996;")
+            modelLayout.addWidget(modelLabel)
+            modelLayout.addStretch()
+
+            layout.addWidget(modelFrame)
+
+        # Strength slider (if applicable)
+        if self.operation.supportsStrength():
+            strengthFrame = QFrame()
+            strengthFrame.setFrameShape(QFrame.NoFrame)
+            strengthLayout = QVBoxLayout(strengthFrame)
+            strengthLayout.setContentsMargins(0, 4, 0, 0)
+            strengthLayout.setSpacing(2)
+
+            strengthHeaderLayout = QHBoxLayout()
+            strengthHeaderLayout.setContentsMargins(0, 0, 0, 0)
+
+            strengthTitleLabel = QLabel("Strength:")
+            strengthTitleLabel.setStyleSheet("color: #aaa;")
+            strengthHeaderLayout.addWidget(strengthTitleLabel)
+
+            self.strengthValueLabel = QLabel(f"{int((self.operation.strength or 1.0) * 100)}%")
+            self.strengthValueLabel.setStyleSheet("color: #aaa;")
+            self.strengthValueLabel.setMinimumWidth(35)
+            strengthHeaderLayout.addWidget(self.strengthValueLabel)
+            strengthHeaderLayout.addStretch()
+
+            strengthLayout.addLayout(strengthHeaderLayout)
+
+            sliderFrame = QFrame()
+            sliderFrame.setFrameShape(QFrame.NoFrame)
+            sliderLayout = QHBoxLayout(sliderFrame)
+            sliderLayout.setContentsMargins(12, 0, 0, 0)
+
+            self.strengthSlider = QSlider(Qt.Horizontal)
+            self.strengthSlider.setMinimum(0)
+            self.strengthSlider.setMaximum(100)
+            self.strengthSlider.setValue(int((self.operation.strength or 1.0) * 100))
+            self.strengthSlider.setTickPosition(QSlider.TicksBothSides)
+            self.strengthSlider.setTickInterval(10)
+            self.strengthSlider.valueChanged.connect(self._onStrengthChanged)
+            sliderLayout.addWidget(self.strengthSlider)
+
+            strengthLayout.addWidget(sliderFrame)
+            layout.addWidget(strengthFrame)
+
+        # Scale display (if applicable)
+        if self.operation.scale is not None and self.operation.scale < 1.0:
+            scaleFrame = QFrame()
+            scaleFrame.setFrameShape(QFrame.NoFrame)
+            scaleLayout = QHBoxLayout(scaleFrame)
+            scaleLayout.setContentsMargins(0, 4, 0, 0)
+            scaleLayout.setSpacing(4)
+
+            scaleTitleLabel = QLabel("Downscale:")
+            scaleTitleLabel.setStyleSheet("color: #aaa;")
+            scaleLayout.addWidget(scaleTitleLabel)
+
+            scaleValue = f"{int(1 / self.operation.scale)}X"
+            scaleValueLabel = QLabel(scaleValue)
+            scaleValueLabel.setStyleSheet("color: #9a9996;")
+            scaleLayout.addWidget(scaleValueLabel)
+            scaleLayout.addStretch()
+
+            layout.addWidget(scaleFrame)
+
+        # Mask selector button (always show, even if no masks yet)
+        self._createMaskSelector(layout)
+
+    def _createMaskSelector(self, layout: QVBoxLayout):
+        """Create the mask selector button."""
+        masksFrame = QFrame()
+        masksFrame.setFrameShape(QFrame.NoFrame)
+        masksLayout = QHBoxLayout(masksFrame)
+        masksLayout.setContentsMargins(0, 4, 0, 0)
+        masksLayout.setSpacing(4)
+
+        self.maskSelector = MaskSelectorButton()
+        self.maskSelector.setMasks(
+            self.availableMasks, selectedMasks=self.operation.masks
+        )
+        self.maskSelector.selectionChanged.connect(self._onMaskSelectionChanged)
+        masksLayout.addWidget(self.maskSelector)
+        masksLayout.addStretch()
+
+        layout.addWidget(masksFrame)
+        self.masksFrame = masksFrame
+
+    def _getOperationDisplayName(self) -> str:
+        """Get a human-readable name for the operation."""
+        if self.operation.operation_type:
+            return self.operation.operation_type.value
+        return "Unknown"
+
+    def _onStrengthChanged(self, value: int):
+        """Handle strength slider value changes."""
+        strength = value / 100.0
+        self.strengthValueLabel.setText(f"{value}%")
+        self.strengthChanged.emit(self.operation, strength)
+
+    def _onMaskSelectionChanged(self, selectedMasks: list):
+        """Handle mask selection changes from the mask selector."""
+        self.masksChanged.emit(self.operation, selectedMasks)
+
+    def getStrength(self) -> float:
+        """Get the current strength value."""
+        if hasattr(self, 'strengthSlider'):
+            return self.strengthSlider.value() / 100.0
+        return self.operation.strength or 1.0
+
+    def getSelectedMasks(self) -> List[Mask]:
+        """Get the currently selected masks."""
+        if self.maskSelector:
+            return self.maskSelector.getSelection()
+        return []
+
+    def updateAvailableMasks(self, newMasks: List[Mask]):
+        """Update the available masks in the mask selector."""
+        if len(newMasks) == len(self.availableMasks):
+            return
+
+        self.availableMasks = newMasks
+
+        if self.maskSelector:
+            self.maskSelector.setMasks(newMasks, selectedMasks=self.operation.masks)

--- a/src/enhance/ui/operation_widget.py
+++ b/src/enhance/ui/operation_widget.py
@@ -75,7 +75,8 @@ class OperationWidget(QFrame):
             strengthTitleLabel.setStyleSheet("color: #aaa;")
             strengthHeaderLayout.addWidget(strengthTitleLabel)
 
-            self.strengthValueLabel = QLabel(f"{int((self.operation.strength or 1.0) * 100)}%")
+            strengthPct = int((self.operation.strength if self.operation.strength is not None else 1.0) * 100)
+            self.strengthValueLabel = QLabel(f"{strengthPct}%")
             self.strengthValueLabel.setStyleSheet("color: #aaa;")
             self.strengthValueLabel.setMinimumWidth(35)
             strengthHeaderLayout.addWidget(self.strengthValueLabel)
@@ -91,7 +92,7 @@ class OperationWidget(QFrame):
             self.strengthSlider = QSlider(Qt.Horizontal)
             self.strengthSlider.setMinimum(0)
             self.strengthSlider.setMaximum(100)
-            self.strengthSlider.setValue(int((self.operation.strength or 1.0) * 100))
+            self.strengthSlider.setValue(strengthPct)
             self.strengthSlider.setTickPosition(QSlider.TicksBothSides)
             self.strengthSlider.setTickInterval(10)
             self.strengthSlider.valueChanged.connect(self._onStrengthChanged)

--- a/src/enhance/ui/operation_widget.py
+++ b/src/enhance/ui/operation_widget.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QSlider,
 )
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFontMetrics
 
 from enhance.lib.file import AppliedOperation, Mask
 from enhance.ui.mask_selector import MaskSelectorButton
@@ -50,10 +51,16 @@ class OperationWidget(QFrame):
             modelFrame = QFrame()
             modelFrame.setFrameShape(QFrame.NoFrame)
             modelLayout = QHBoxLayout(modelFrame)
-            modelLayout.setContentsMargins(12, 0, 0, 0)
+            modelLayout.setContentsMargins(0, 0, 0, 0)
             modelLayout.setSpacing(4)
 
-            modelLabel = QLabel(self.operation.model)
+            modelLabel = QLabel()
+            metrics = QFontMetrics(modelLabel.font())
+            elided = metrics.elidedText(
+                self.operation.model, Qt.TextElideMode.ElideMiddle, 200
+            )
+            modelLabel.setText(elided)
+            modelLabel.setToolTip(self.operation.model)
             modelLabel.setStyleSheet("color: #9a9996;")
             modelLayout.addWidget(modelLabel)
             modelLayout.addStretch()
@@ -87,7 +94,7 @@ class OperationWidget(QFrame):
             sliderFrame = QFrame()
             sliderFrame.setFrameShape(QFrame.NoFrame)
             sliderLayout = QHBoxLayout(sliderFrame)
-            sliderLayout.setContentsMargins(12, 0, 0, 0)
+            sliderLayout.setContentsMargins(0, 0, 0, 0)
 
             self.strengthSlider = QSlider(Qt.Horizontal)
             self.strengthSlider.setMinimum(0)

--- a/src/enhance/ui/operation_widget.py
+++ b/src/enhance/ui/operation_widget.py
@@ -19,11 +19,11 @@ class OperationWidget(QFrame):
     strengthChanged = Signal(AppliedOperation, float)
     masksChanged = Signal(AppliedOperation, list)
 
-    def __init__(self, operation: AppliedOperation, availableMasks: List[Mask] = None, parent=None):
+    def __init__(self, operation: AppliedOperation, available_masks: List[Mask] = None, parent=None):
         super().__init__(parent)
         self.operation = operation
-        self.availableMasks = availableMasks if availableMasks else []
-        self.maskSelector: MaskSelectorButton = None
+        self.available_masks = available_masks if available_masks else []
+        self.mask_selector: MaskSelectorButton = None
         self.setupUi()
 
     def setupUi(self):
@@ -42,148 +42,148 @@ class OperationWidget(QFrame):
         layout.setSpacing(4)
 
         # Operation name header
-        nameLabel = QLabel(self._getOperationDisplayName())
-        nameLabel.setStyleSheet("font-weight: bold; color: #fff;")
-        layout.addWidget(nameLabel)
+        name_label = QLabel(self._get_operation_display_name())
+        name_label.setStyleSheet("font-weight: bold; color: #fff;")
+        layout.addWidget(name_label)
 
         # Model name (if applicable)
         if self.operation.model:
-            modelFrame = QFrame()
-            modelFrame.setFrameShape(QFrame.NoFrame)
-            modelLayout = QHBoxLayout(modelFrame)
-            modelLayout.setContentsMargins(0, 0, 0, 0)
-            modelLayout.setSpacing(4)
+            model_frame = QFrame()
+            model_frame.setFrameShape(QFrame.NoFrame)
+            model_layout = QHBoxLayout(model_frame)
+            model_layout.setContentsMargins(0, 0, 0, 0)
+            model_layout.setSpacing(4)
 
-            modelLabel = QLabel()
-            metrics = QFontMetrics(modelLabel.font())
+            model_label = QLabel()
+            metrics = QFontMetrics(model_label.font())
             elided = metrics.elidedText(
                 self.operation.model, Qt.TextElideMode.ElideMiddle, 200
             )
-            modelLabel.setText(elided)
-            modelLabel.setToolTip(self.operation.model)
-            modelLabel.setStyleSheet("color: #9a9996;")
-            modelLayout.addWidget(modelLabel)
-            modelLayout.addStretch()
+            model_label.setText(elided)
+            model_label.setToolTip(self.operation.model)
+            model_label.setStyleSheet("color: #9a9996;")
+            model_layout.addWidget(model_label)
+            model_layout.addStretch()
 
-            layout.addWidget(modelFrame)
+            layout.addWidget(model_frame)
 
         # Strength slider (if applicable)
         if self.operation.supportsStrength():
-            strengthFrame = QFrame()
-            strengthFrame.setFrameShape(QFrame.NoFrame)
-            strengthLayout = QVBoxLayout(strengthFrame)
-            strengthLayout.setContentsMargins(0, 4, 0, 0)
-            strengthLayout.setSpacing(2)
+            strength_frame = QFrame()
+            strength_frame.setFrameShape(QFrame.NoFrame)
+            strength_layout = QVBoxLayout(strength_frame)
+            strength_layout.setContentsMargins(0, 4, 0, 0)
+            strength_layout.setSpacing(2)
 
-            strengthHeaderLayout = QHBoxLayout()
-            strengthHeaderLayout.setContentsMargins(0, 0, 0, 0)
+            strength_header_layout = QHBoxLayout()
+            strength_header_layout.setContentsMargins(0, 0, 0, 0)
 
-            strengthTitleLabel = QLabel("Strength:")
-            strengthTitleLabel.setStyleSheet("color: #aaa;")
-            strengthHeaderLayout.addWidget(strengthTitleLabel)
+            strength_title_label = QLabel("Strength:")
+            strength_title_label.setStyleSheet("color: #aaa;")
+            strength_header_layout.addWidget(strength_title_label)
 
-            strengthPct = int((self.operation.strength if self.operation.strength is not None else 1.0) * 100)
-            self.strengthValueLabel = QLabel(f"{strengthPct}%")
-            self.strengthValueLabel.setStyleSheet("color: #aaa;")
-            self.strengthValueLabel.setMinimumWidth(35)
-            strengthHeaderLayout.addWidget(self.strengthValueLabel)
-            strengthHeaderLayout.addStretch()
+            strength_pct = int((self.operation.strength if self.operation.strength is not None else 1.0) * 100)
+            self.strength_value_label = QLabel(f"{strength_pct}%")
+            self.strength_value_label.setStyleSheet("color: #aaa;")
+            self.strength_value_label.setMinimumWidth(35)
+            strength_header_layout.addWidget(self.strength_value_label)
+            strength_header_layout.addStretch()
 
-            strengthLayout.addLayout(strengthHeaderLayout)
+            strength_layout.addLayout(strength_header_layout)
 
-            sliderFrame = QFrame()
-            sliderFrame.setFrameShape(QFrame.NoFrame)
-            sliderLayout = QHBoxLayout(sliderFrame)
-            sliderLayout.setContentsMargins(0, 0, 0, 0)
+            slider_frame = QFrame()
+            slider_frame.setFrameShape(QFrame.NoFrame)
+            slider_layout = QHBoxLayout(slider_frame)
+            slider_layout.setContentsMargins(0, 0, 0, 0)
 
-            self.strengthSlider = QSlider(Qt.Horizontal)
-            self.strengthSlider.setMinimum(0)
-            self.strengthSlider.setMaximum(100)
-            self.strengthSlider.setValue(strengthPct)
-            self.strengthSlider.setTickPosition(QSlider.TicksBothSides)
-            self.strengthSlider.setTickInterval(10)
-            self.strengthSlider.valueChanged.connect(self._onStrengthChanged)
-            sliderLayout.addWidget(self.strengthSlider)
+            self.strength_slider = QSlider(Qt.Horizontal)
+            self.strength_slider.setMinimum(0)
+            self.strength_slider.setMaximum(100)
+            self.strength_slider.setValue(strength_pct)
+            self.strength_slider.setTickPosition(QSlider.TicksBothSides)
+            self.strength_slider.setTickInterval(10)
+            self.strength_slider.valueChanged.connect(self._on_strength_changed)
+            slider_layout.addWidget(self.strength_slider)
 
-            strengthLayout.addWidget(sliderFrame)
-            layout.addWidget(strengthFrame)
+            strength_layout.addWidget(slider_frame)
+            layout.addWidget(strength_frame)
 
         # Scale display (if applicable)
         if self.operation.scale is not None and self.operation.scale < 1.0:
-            scaleFrame = QFrame()
-            scaleFrame.setFrameShape(QFrame.NoFrame)
-            scaleLayout = QHBoxLayout(scaleFrame)
-            scaleLayout.setContentsMargins(0, 4, 0, 0)
-            scaleLayout.setSpacing(4)
+            scale_frame = QFrame()
+            scale_frame.setFrameShape(QFrame.NoFrame)
+            scale_layout = QHBoxLayout(scale_frame)
+            scale_layout.setContentsMargins(0, 4, 0, 0)
+            scale_layout.setSpacing(4)
 
-            scaleTitleLabel = QLabel("Downscale:")
-            scaleTitleLabel.setStyleSheet("color: #aaa;")
-            scaleLayout.addWidget(scaleTitleLabel)
+            scale_title_label = QLabel("Downscale:")
+            scale_title_label.setStyleSheet("color: #aaa;")
+            scale_layout.addWidget(scale_title_label)
 
-            scaleValue = f"{int(1 / self.operation.scale)}X"
-            scaleValueLabel = QLabel(scaleValue)
-            scaleValueLabel.setStyleSheet("color: #9a9996;")
-            scaleLayout.addWidget(scaleValueLabel)
-            scaleLayout.addStretch()
+            scale_value = f"{int(1 / self.operation.scale)}X"
+            scale_value_label = QLabel(scale_value)
+            scale_value_label.setStyleSheet("color: #9a9996;")
+            scale_layout.addWidget(scale_value_label)
+            scale_layout.addStretch()
 
-            layout.addWidget(scaleFrame)
+            layout.addWidget(scale_frame)
 
         # Mask selector button (always show, even if no masks yet)
-        self._createMaskSelector(layout)
+        self._create_mask_selector(layout)
 
-    def _createMaskSelector(self, layout: QVBoxLayout):
+    def _create_mask_selector(self, layout: QVBoxLayout):
         """Create the mask selector button."""
-        masksFrame = QFrame()
-        masksFrame.setFrameShape(QFrame.NoFrame)
-        masksLayout = QHBoxLayout(masksFrame)
-        masksLayout.setContentsMargins(0, 4, 0, 0)
-        masksLayout.setSpacing(4)
+        masks_frame = QFrame()
+        masks_frame.setFrameShape(QFrame.NoFrame)
+        masks_layout = QHBoxLayout(masks_frame)
+        masks_layout.setContentsMargins(0, 4, 0, 0)
+        masks_layout.setSpacing(4)
 
-        self.maskSelector = MaskSelectorButton()
-        self.maskSelector.setMasks(
-            self.availableMasks, selectedMasks=self.operation.masks
+        self.mask_selector = MaskSelectorButton()
+        self.mask_selector.set_masks(
+            self.available_masks, selected_masks=self.operation.masks
         )
-        self.maskSelector.selectionChanged.connect(self._onMaskSelectionChanged)
-        masksLayout.addWidget(self.maskSelector)
-        masksLayout.addStretch()
+        self.mask_selector.selectionChanged.connect(self._on_mask_selection_changed)
+        masks_layout.addWidget(self.mask_selector)
+        masks_layout.addStretch()
 
-        layout.addWidget(masksFrame)
-        self.masksFrame = masksFrame
+        layout.addWidget(masks_frame)
+        self.masks_frame = masks_frame
 
-    def _getOperationDisplayName(self) -> str:
+    def _get_operation_display_name(self) -> str:
         """Get a human-readable name for the operation."""
         if self.operation.operation_type:
             return self.operation.operation_type.value
         return "Unknown"
 
-    def _onStrengthChanged(self, value: int):
+    def _on_strength_changed(self, value: int):
         """Handle strength slider value changes."""
         strength = value / 100.0
-        self.strengthValueLabel.setText(f"{value}%")
+        self.strength_value_label.setText(f"{value}%")
         self.strengthChanged.emit(self.operation, strength)
 
-    def _onMaskSelectionChanged(self, selectedMasks: list):
+    def _on_mask_selection_changed(self, selected_masks: list):
         """Handle mask selection changes from the mask selector."""
-        self.masksChanged.emit(self.operation, selectedMasks)
+        self.masksChanged.emit(self.operation, selected_masks)
 
-    def getStrength(self) -> float:
+    def get_strength(self) -> float:
         """Get the current strength value."""
-        if hasattr(self, 'strengthSlider'):
-            return self.strengthSlider.value() / 100.0
+        if hasattr(self, 'strength_slider'):
+            return self.strength_slider.value() / 100.0
         return self.operation.strength or 1.0
 
-    def getSelectedMasks(self) -> List[Mask]:
+    def get_selected_masks(self) -> List[Mask]:
         """Get the currently selected masks."""
-        if self.maskSelector:
-            return self.maskSelector.getSelection()
+        if self.mask_selector:
+            return self.mask_selector.get_selection()
         return []
 
-    def updateAvailableMasks(self, newMasks: List[Mask]):
+    def update_available_masks(self, new_masks: List[Mask]):
         """Update the available masks in the mask selector."""
-        if len(newMasks) == len(self.availableMasks):
+        if len(new_masks) == len(self.available_masks):
             return
 
-        self.availableMasks = newMasks
+        self.available_masks = new_masks
 
-        if self.maskSelector:
-            self.maskSelector.setMasks(newMasks, selectedMasks=self.operation.masks)
+        if self.mask_selector:
+            self.mask_selector.set_masks(new_masks, selected_masks=self.operation.masks)

--- a/src/enhance/ui/operation_widget.py
+++ b/src/enhance/ui/operation_widget.py
@@ -180,7 +180,9 @@ class OperationWidget(QFrame):
 
     def update_available_masks(self, new_masks: List[Mask]):
         """Update the available masks in the mask selector."""
-        if len(new_masks) == len(self.available_masks):
+        new_keys = [m.uniqueLabel for m in new_masks]
+        old_keys = [m.uniqueLabel for m in self.available_masks]
+        if new_keys == old_keys:
             return
 
         self.available_masks = new_masks

--- a/src/enhance/ui/signals.py
+++ b/src/enhance/ui/signals.py
@@ -69,6 +69,7 @@ class Signals(QObject):
     updateThumbnail: Signal = Signal(QFrame, QWidget)
     drawFileList: Signal = Signal(File)
     appendFile: Signal = Signal(File)
+    createOutputFile: Signal = Signal()
 
     removeFile: Signal = Signal(File, QPushButton)
     saveFile: Signal = Signal(File, QPushButton)
@@ -79,6 +80,8 @@ class Signals(QObject):
     changeZoom: Signal = Signal(float)
 
     taskCompleted: Signal = Signal()
+    
+    updateOperationWidgetMasks: Signal = Signal()  # Signal to update masks on operation widgets
 
 
 lowpri_threadpool = QThreadPool()

--- a/src/enhance/ui/ui_dialog_model.py
+++ b/src/enhance/ui/ui_dialog_model.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ################################################################################
-## Form generated from reading UI file 'dialog_modelQjiFYi.ui'
+## Form generated from reading UI file 'dialog_modeluVJHfh.ui'
 ##
 ## Created by: Qt User Interface Compiler version 6.4.2
 ##
@@ -25,8 +25,8 @@ class Ui_Dialog(object):
     def setupUi(self, Dialog):
         if not Dialog.objectName():
             Dialog.setObjectName(u"Dialog")
-        Dialog.resize(1098, 500)
-        Dialog.setMinimumSize(QSize(0, 400))
+        Dialog.resize(1098, 608)
+        Dialog.setMinimumSize(QSize(0, 480))
         self.verticalLayout = QVBoxLayout(Dialog)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.frame = QFrame(Dialog)
@@ -79,27 +79,60 @@ class Ui_Dialog(object):
         self.frame_2.setFrameShadow(QFrame.Raised)
         self.gridLayout = QGridLayout(self.frame_2)
         self.gridLayout.setObjectName(u"gridLayout")
-        self.frame_4 = QFrame(self.frame_2)
-        self.frame_4.setObjectName(u"frame_4")
-        self.frame_4.setFrameShape(QFrame.NoFrame)
-        self.frame_4.setFrameShadow(QFrame.Plain)
-        self.horizontalLayout_2 = QHBoxLayout(self.frame_4)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.label_3 = QLabel(self.frame_4)
-        self.label_3.setObjectName(u"label_3")
-        self.label_3.setMinimumSize(QSize(100, 0))
-        self.label_3.setMaximumSize(QSize(100, 16777215))
+        self.frame_masks = QFrame(self.frame_2)
+        self.frame_masks.setObjectName(u"frame_masks")
+        self.frame_masks.setFrameShape(QFrame.NoFrame)
+        self.frame_masks.setFrameShadow(QFrame.Plain)
+        self.horizontalLayout_8 = QHBoxLayout(self.frame_masks)
+        self.horizontalLayout_8.setSpacing(0)
+        self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
+        self.horizontalLayout_8.setContentsMargins(0, 0, 0, 0)
+        self.label_masks = QLabel(self.frame_masks)
+        self.label_masks.setObjectName(u"label_masks")
+        self.label_masks.setMinimumSize(QSize(100, 0))
+        self.label_masks.setMaximumSize(QSize(100, 16777215))
 
-        self.horizontalLayout_2.addWidget(self.label_3)
+        self.horizontalLayout_8.addWidget(self.label_masks)
 
-        self.tileSize_combobox = QComboBox(self.frame_4)
-        self.tileSize_combobox.setObjectName(u"tileSize_combobox")
+        self.frame_masksSelect = QFrame(self.frame_masks)
+        self.frame_masksSelect.setObjectName(u"frame_masksSelect")
+        self.frame_masksSelect.setFrameShape(QFrame.NoFrame)
+        self.frame_masksSelect.setFrameShadow(QFrame.Plain)
+        self.horizontalLayout_invertMask = QHBoxLayout(self.frame_masksSelect)
+        self.horizontalLayout_invertMask.setObjectName(u"horizontalLayout_invertMask")
+        self.horizontalLayout_invertMask.setContentsMargins(12, 6, 6, 6)
+        self.label_placeholder = QLabel(self.frame_masksSelect)
+        self.label_placeholder.setObjectName(u"label_placeholder")
 
-        self.horizontalLayout_2.addWidget(self.tileSize_combobox)
+        self.horizontalLayout_invertMask.addWidget(self.label_placeholder)
 
 
-        self.gridLayout.addWidget(self.frame_4, 3, 0, 1, 1)
+        self.horizontalLayout_8.addWidget(self.frame_masksSelect, 0, Qt.AlignLeft)
+
+
+        self.gridLayout.addWidget(self.frame_masks, 5, 0, 1, 1)
+
+        self.frame_8 = QFrame(self.frame_2)
+        self.frame_8.setObjectName(u"frame_8")
+        self.frame_8.setFrameShape(QFrame.NoFrame)
+        self.frame_8.setFrameShadow(QFrame.Raised)
+        self.horizontalLayout_6 = QHBoxLayout(self.frame_8)
+        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.horizontalLayout_6.setContentsMargins(0, 0, 0, 0)
+        self.label_5 = QLabel(self.frame_8)
+        self.label_5.setObjectName(u"label_5")
+        self.label_5.setMinimumSize(QSize(100, 0))
+        self.label_5.setMaximumSize(QSize(100, 16777215))
+
+        self.horizontalLayout_6.addWidget(self.label_5)
+
+        self.checkBox_maintainScale = QCheckBox(self.frame_8)
+        self.checkBox_maintainScale.setObjectName(u"checkBox_maintainScale")
+
+        self.horizontalLayout_6.addWidget(self.checkBox_maintainScale)
+
+
+        self.gridLayout.addWidget(self.frame_8, 0, 0, 1, 1)
 
         self.frame_5 = QFrame(self.frame_2)
         self.frame_5.setObjectName(u"frame_5")
@@ -145,27 +178,27 @@ class Ui_Dialog(object):
 
         self.gridLayout.addWidget(self.frame_3, 1, 0, 1, 1)
 
-        self.frame_8 = QFrame(self.frame_2)
-        self.frame_8.setObjectName(u"frame_8")
-        self.frame_8.setFrameShape(QFrame.NoFrame)
-        self.frame_8.setFrameShadow(QFrame.Raised)
-        self.horizontalLayout_6 = QHBoxLayout(self.frame_8)
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.horizontalLayout_6.setContentsMargins(0, 0, 0, 0)
-        self.label_5 = QLabel(self.frame_8)
-        self.label_5.setObjectName(u"label_5")
-        self.label_5.setMinimumSize(QSize(100, 0))
-        self.label_5.setMaximumSize(QSize(100, 16777215))
+        self.frame_4 = QFrame(self.frame_2)
+        self.frame_4.setObjectName(u"frame_4")
+        self.frame_4.setFrameShape(QFrame.NoFrame)
+        self.frame_4.setFrameShadow(QFrame.Plain)
+        self.horizontalLayout_2 = QHBoxLayout(self.frame_4)
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.label_3 = QLabel(self.frame_4)
+        self.label_3.setObjectName(u"label_3")
+        self.label_3.setMinimumSize(QSize(100, 0))
+        self.label_3.setMaximumSize(QSize(100, 16777215))
 
-        self.horizontalLayout_6.addWidget(self.label_5)
+        self.horizontalLayout_2.addWidget(self.label_3)
 
-        self.checkBox_maintainScale = QCheckBox(self.frame_8)
-        self.checkBox_maintainScale.setObjectName(u"checkBox_maintainScale")
+        self.tileSize_combobox = QComboBox(self.frame_4)
+        self.tileSize_combobox.setObjectName(u"tileSize_combobox")
 
-        self.horizontalLayout_6.addWidget(self.checkBox_maintainScale)
+        self.horizontalLayout_2.addWidget(self.tileSize_combobox)
 
 
-        self.gridLayout.addWidget(self.frame_8, 0, 0, 1, 1)
+        self.gridLayout.addWidget(self.frame_4, 3, 0, 1, 1)
 
 
         self.verticalLayout.addWidget(self.frame_2)
@@ -219,11 +252,13 @@ class Ui_Dialog(object):
         self.label_6.setText("")
         self.label_7.setText(QCoreApplication.translate("Dialog", u"You have no models installed. Click \"Add and Manage Models\" below.", None))
         self.label.setText(QCoreApplication.translate("Dialog", u"Choose Model:", None))
-        self.label_3.setText(QCoreApplication.translate("Dialog", u"Tile Size:", None))
-        self.label_4.setText(QCoreApplication.translate("Dialog", u"Tile Padding:", None))
-        self.label_2.setText(QCoreApplication.translate("Dialog", u"Device:", None))
+        self.label_masks.setText(QCoreApplication.translate("Dialog", u"Apply to:", None))
+        self.label_placeholder.setText(QCoreApplication.translate("Dialog", u"Placeholder", None))
         self.label_5.setText("")
         self.checkBox_maintainScale.setText(QCoreApplication.translate("Dialog", u"Maintain Original Scale", None))
+        self.label_4.setText(QCoreApplication.translate("Dialog", u"Tile Padding:", None))
+        self.label_2.setText(QCoreApplication.translate("Dialog", u"Device:", None))
+        self.label_3.setText(QCoreApplication.translate("Dialog", u"Tile Size:", None))
         self.pushButton_modelManager.setText(QCoreApplication.translate("Dialog", u"Add and Manage Models", None))
     # retranslateUi
 

--- a/src/enhance/ui/ui_dialog_model_wrap.py
+++ b/src/enhance/ui/ui_dialog_model_wrap.py
@@ -100,12 +100,12 @@ class UI_DialogModel(Ui_Dialog):
             self.maskSelector = MaskSelectorButton()
             self.frame_masksSelect.layout().addWidget(self.maskSelector)
 
-        self.maskSelector.setMasks(masks)
+        self.maskSelector.set_masks(masks)
 
-    def getSelectedMasks(self) -> List[Mask]:
+    def get_selected_masks(self) -> List[Mask]:
         """Get the list of selected masks with per-mask inverted property set."""
         if self.maskSelector:
-            return self.maskSelector.getSelection()
+            return self.maskSelector.get_selection()
         return []
 
     def showModelManager(self):

--- a/src/enhance/ui/ui_interface.py
+++ b/src/enhance/ui/ui_interface.py
@@ -982,7 +982,7 @@ class Ui_MainWindow(object):
         self.label_modelname.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><span style=\" color:#9a9996;\"/></p></body></html>", None))
         self.label_9.setText(QCoreApplication.translate("MainWindow", u"Shape:", None))
         self.label_shape.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p/></body></html>", None))
-        self.group_postprocess.setTitle(QCoreApplication.translate("MainWindow", u"Post Processing", None))
+        self.group_postprocess.setTitle(QCoreApplication.translate("MainWindow", u"Operations", None))
         self.label_6.setText(QCoreApplication.translate("MainWindow", u"Blur:", None))
         self.label_blur_amt.setText(QCoreApplication.translate("MainWindow", u"0", None))
         self.label_5.setText(QCoreApplication.translate("MainWindow", u"Downscale:", None))

--- a/src/enhance/ui/ui_interface.py
+++ b/src/enhance/ui/ui_interface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ################################################################################
-## Form generated from reading UI file 'interfaceYbstwi.ui'
+## Form generated from reading UI file 'interfacepCqqSq.ui'
 ##
 ## Created by: Qt User Interface Compiler version 6.4.2
 ##
@@ -18,7 +18,7 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
 from PySide6.QtWidgets import (QAbstractScrollArea, QApplication, QFrame, QGridLayout,
     QHBoxLayout, QLabel, QLayout, QMainWindow,
     QProgressBar, QPushButton, QScrollArea, QSizePolicy,
-    QSlider, QVBoxLayout, QWidget)
+    QSlider, QSpacerItem, QVBoxLayout, QWidget)
 import icons_rc
 
 class Ui_MainWindow(object):
@@ -352,7 +352,7 @@ class Ui_MainWindow(object):
 
         self.frame_sidebar = QFrame(self.frame1)
         self.frame_sidebar.setObjectName(u"frame_sidebar")
-        sizePolicy5 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Maximum)
+        sizePolicy5 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         sizePolicy5.setHorizontalStretch(0)
         sizePolicy5.setVerticalStretch(0)
         sizePolicy5.setHeightForWidth(self.frame_sidebar.sizePolicy().hasHeightForWidth())
@@ -400,6 +400,7 @@ class Ui_MainWindow(object):
         self.frame_label_info.setFrameShape(QFrame.NoFrame)
         self.frame_label_info.setFrameShadow(QFrame.Raised)
         self.layout_label_info = QVBoxLayout(self.frame_label_info)
+        self.layout_label_info.setSpacing(0)
         self.layout_label_info.setObjectName(u"layout_label_info")
         self.layout_label_info.setContentsMargins(0, 12, 0, 0)
         self.label_7 = QLabel(self.frame_label_info)
@@ -409,6 +410,13 @@ class Ui_MainWindow(object):
         self.label_7.setFont(font5)
 
         self.layout_label_info.addWidget(self.label_7)
+
+        self.line_9 = QFrame(self.frame_label_info)
+        self.line_9.setObjectName(u"line_9")
+        self.line_9.setFrameShadow(QFrame.Plain)
+        self.line_9.setFrameShape(QFrame.HLine)
+
+        self.layout_label_info.addWidget(self.line_9)
 
 
         self.verticalLayout_3.addWidget(self.frame_label_info)
@@ -572,6 +580,7 @@ class Ui_MainWindow(object):
         self.frame_label_selection.setFrameShape(QFrame.NoFrame)
         self.frame_label_selection.setFrameShadow(QFrame.Raised)
         self.layout_label_selection = QVBoxLayout(self.frame_label_selection)
+        self.layout_label_selection.setSpacing(0)
         self.layout_label_selection.setObjectName(u"layout_label_selection")
         self.layout_label_selection.setContentsMargins(0, 12, 0, 0)
         self.label_10 = QLabel(self.frame_label_selection)
@@ -579,6 +588,13 @@ class Ui_MainWindow(object):
         self.label_10.setFont(font5)
 
         self.layout_label_selection.addWidget(self.label_10)
+
+        self.line_7 = QFrame(self.frame_label_selection)
+        self.line_7.setObjectName(u"line_7")
+        self.line_7.setFrameShadow(QFrame.Plain)
+        self.line_7.setFrameShape(QFrame.HLine)
+
+        self.layout_label_selection.addWidget(self.line_7)
 
 
         self.verticalLayout_3.addWidget(self.frame_label_selection)
@@ -623,6 +639,7 @@ class Ui_MainWindow(object):
         self.frame_label_operations.setFrameShape(QFrame.NoFrame)
         self.frame_label_operations.setFrameShadow(QFrame.Raised)
         self.layout_label_operations = QVBoxLayout(self.frame_label_operations)
+        self.layout_label_operations.setSpacing(0)
         self.layout_label_operations.setObjectName(u"layout_label_operations")
         self.layout_label_operations.setContentsMargins(0, 12, 0, 0)
         self.label_11 = QLabel(self.frame_label_operations)
@@ -630,6 +647,13 @@ class Ui_MainWindow(object):
         self.label_11.setFont(font5)
 
         self.layout_label_operations.addWidget(self.label_11)
+
+        self.line_3 = QFrame(self.frame_label_operations)
+        self.line_3.setObjectName(u"line_3")
+        self.line_3.setFrameShadow(QFrame.Plain)
+        self.line_3.setFrameShape(QFrame.HLine)
+
+        self.layout_label_operations.addWidget(self.line_3)
 
 
         self.verticalLayout_3.addWidget(self.frame_label_operations)
@@ -717,42 +741,83 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_9.addWidget(self.frame_5)
 
-        self.line_6 = QFrame(self.frame_blend)
+        self.pushButton_postprocess_apply = QPushButton(self.frame_blend)
+        self.pushButton_postprocess_apply.setObjectName(u"pushButton_postprocess_apply")
+
+        self.verticalLayout_9.addWidget(self.pushButton_postprocess_apply)
+
+
+        self.verticalLayout_20.addWidget(self.frame_blend)
+
+
+        self.verticalLayout_3.addWidget(self.group_postprocess)
+
+        self.line_6 = QFrame(self.frame_sidebar)
         self.line_6.setObjectName(u"line_6")
         self.line_6.setStyleSheet(u"color: rgb(92, 92, 92);")
         self.line_6.setFrameShadow(QFrame.Plain)
         self.line_6.setFrameShape(QFrame.HLine)
 
-        self.verticalLayout_9.addWidget(self.line_6)
+        self.verticalLayout_3.addWidget(self.line_6)
 
-
-        self.verticalLayout_20.addWidget(self.frame_blend)
-
-        self.pushButton_postprocess_apply = QPushButton(self.group_postprocess)
-        self.pushButton_postprocess_apply.setObjectName(u"pushButton_postprocess_apply")
-
-        self.verticalLayout_20.addWidget(self.pushButton_postprocess_apply)
-
-
-        self.verticalLayout_3.addWidget(self.group_postprocess)
-
-        self.pushButton_run = QPushButton(self.frame_sidebar)
+        self.frame_11 = QFrame(self.frame_sidebar)
+        self.frame_11.setObjectName(u"frame_11")
+        self.frame_11.setFrameShape(QFrame.NoFrame)
+        self.frame_11.setFrameShadow(QFrame.Plain)
+        self.verticalLayout_17 = QVBoxLayout(self.frame_11)
+        self.verticalLayout_17.setObjectName(u"verticalLayout_17")
+        self.verticalLayout_17.setContentsMargins(0, 0, 0, 0)
+        self.pushButton_run = QPushButton(self.frame_11)
         self.pushButton_run.setObjectName(u"pushButton_run")
 
-        self.verticalLayout_3.addWidget(self.pushButton_run)
+        self.verticalLayout_17.addWidget(self.pushButton_run)
 
-        self.pushButton_denoise = QPushButton(self.frame_sidebar)
+        self.pushButton_denoise = QPushButton(self.frame_11)
         self.pushButton_denoise.setObjectName(u"pushButton_denoise")
 
-        self.verticalLayout_3.addWidget(self.pushButton_denoise)
+        self.verticalLayout_17.addWidget(self.pushButton_denoise)
 
-        self.pushButton_upscale = QPushButton(self.frame_sidebar)
+        self.pushButton_upscale = QPushButton(self.frame_11)
         self.pushButton_upscale.setObjectName(u"pushButton_upscale")
 
-        self.verticalLayout_3.addWidget(self.pushButton_upscale)
+        self.verticalLayout_17.addWidget(self.pushButton_upscale)
 
 
-        self.horizontalLayout.addWidget(self.frame_sidebar, 0, Qt.AlignTop)
+        self.verticalLayout_3.addWidget(self.frame_11)
+
+        self.line_2 = QFrame(self.frame_sidebar)
+        self.line_2.setObjectName(u"line_2")
+        self.line_2.setFrameShape(QFrame.HLine)
+        self.line_2.setFrameShadow(QFrame.Sunken)
+
+        self.verticalLayout_3.addWidget(self.line_2)
+
+        self.frame_7 = QFrame(self.frame_sidebar)
+        self.frame_7.setObjectName(u"frame_7")
+        self.frame_7.setFrameShape(QFrame.NoFrame)
+        self.frame_7.setFrameShadow(QFrame.Plain)
+        self.verticalLayout_16 = QVBoxLayout(self.frame_7)
+        self.verticalLayout_16.setObjectName(u"verticalLayout_16")
+        self.verticalLayout_16.setContentsMargins(0, 0, 0, 0)
+        self.pushButton_saveFile = QPushButton(self.frame_7)
+        self.pushButton_saveFile.setObjectName(u"pushButton_saveFile")
+
+        self.verticalLayout_16.addWidget(self.pushButton_saveFile)
+
+
+        self.verticalLayout_3.addWidget(self.frame_7)
+
+        self.pushButton_delete = QPushButton(self.frame_sidebar)
+        self.pushButton_delete.setObjectName(u"pushButton_delete")
+
+        self.verticalLayout_3.addWidget(self.pushButton_delete)
+
+        self.verticalSpacer_sidebar = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+
+        self.verticalLayout_3.addItem(self.verticalSpacer_sidebar)
+
+
+        self.horizontalLayout.addWidget(self.frame_sidebar)
 
 
         self.verticalLayout_2.addWidget(self.frame1)
@@ -930,6 +995,8 @@ class Ui_MainWindow(object):
         self.pushButton_run.setText(QCoreApplication.translate("MainWindow", u"Sharpen", None))
         self.pushButton_denoise.setText(QCoreApplication.translate("MainWindow", u"Denoise", None))
         self.pushButton_upscale.setText(QCoreApplication.translate("MainWindow", u"Upscale", None))
+        self.pushButton_saveFile.setText(QCoreApplication.translate("MainWindow", u"Save File", None))
+        self.pushButton_delete.setText(QCoreApplication.translate("MainWindow", u"Delete File", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Files", None))
         self.label_files_count.setText("")
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"text", None))

--- a/src/enhance/ui/ui_interface.py
+++ b/src/enhance/ui/ui_interface.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 ################################################################################
-## Form generated from reading UI file 'interfacegksxeT.ui'
+## Form generated from reading UI file 'interfaceYbstwi.ui'
 ##
 ## Created by: Qt User Interface Compiler version 6.4.2
 ##
@@ -15,11 +15,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractScrollArea, QApplication, QCheckBox, QFrame,
-    QGridLayout, QGroupBox, QHBoxLayout, QLabel,
-    QLayout, QMainWindow, QProgressBar, QPushButton,
-    QScrollArea, QSizePolicy, QSlider, QVBoxLayout,
-    QWidget)
+from PySide6.QtWidgets import (QAbstractScrollArea, QApplication, QFrame, QGridLayout,
+    QHBoxLayout, QLabel, QLayout, QMainWindow,
+    QProgressBar, QPushButton, QScrollArea, QSizePolicy,
+    QSlider, QVBoxLayout, QWidget)
 import icons_rc
 
 class Ui_MainWindow(object):
@@ -360,7 +359,7 @@ class Ui_MainWindow(object):
         self.frame_sidebar.setSizePolicy(sizePolicy5)
         self.frame_sidebar.setMinimumSize(QSize(244, 0))
         self.frame_sidebar.setMaximumSize(QSize(100, 16777215))
-        self.frame_sidebar.setFrameShape(QFrame.StyledPanel)
+        self.frame_sidebar.setFrameShape(QFrame.NoFrame)
         self.frame_sidebar.setFrameShadow(QFrame.Plain)
         self.verticalLayout_3 = QVBoxLayout(self.frame_sidebar)
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
@@ -383,20 +382,10 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_3.addWidget(self.line_8)
 
-        self.pushButton_run = QPushButton(self.frame_sidebar)
-        self.pushButton_run.setObjectName(u"pushButton_run")
+        self.pushButton_modelManager = QPushButton(self.frame_sidebar)
+        self.pushButton_modelManager.setObjectName(u"pushButton_modelManager")
 
-        self.verticalLayout_3.addWidget(self.pushButton_run)
-
-        self.pushButton_denoise = QPushButton(self.frame_sidebar)
-        self.pushButton_denoise.setObjectName(u"pushButton_denoise")
-
-        self.verticalLayout_3.addWidget(self.pushButton_denoise)
-
-        self.pushButton_upscale = QPushButton(self.frame_sidebar)
-        self.pushButton_upscale.setObjectName(u"pushButton_upscale")
-
-        self.verticalLayout_3.addWidget(self.pushButton_upscale)
+        self.verticalLayout_3.addWidget(self.pushButton_modelManager)
 
         self.line = QFrame(self.frame_sidebar)
         self.line.setObjectName(u"line")
@@ -406,44 +395,50 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_3.addWidget(self.line)
 
-        self.pushButton_modelManager = QPushButton(self.frame_sidebar)
-        self.pushButton_modelManager.setObjectName(u"pushButton_modelManager")
+        self.frame_label_info = QFrame(self.frame_sidebar)
+        self.frame_label_info.setObjectName(u"frame_label_info")
+        self.frame_label_info.setFrameShape(QFrame.NoFrame)
+        self.frame_label_info.setFrameShadow(QFrame.Raised)
+        self.layout_label_info = QVBoxLayout(self.frame_label_info)
+        self.layout_label_info.setObjectName(u"layout_label_info")
+        self.layout_label_info.setContentsMargins(0, 12, 0, 0)
+        self.label_7 = QLabel(self.frame_label_info)
+        self.label_7.setObjectName(u"label_7")
+        font5 = QFont()
+        font5.setBold(True)
+        self.label_7.setFont(font5)
 
-        self.verticalLayout_3.addWidget(self.pushButton_modelManager)
+        self.layout_label_info.addWidget(self.label_7)
 
-        self.line_3 = QFrame(self.frame_sidebar)
-        self.line_3.setObjectName(u"line_3")
-        self.line_3.setStyleSheet(u"color: rgb(92, 92, 92);")
-        self.line_3.setFrameShadow(QFrame.Plain)
-        self.line_3.setFrameShape(QFrame.HLine)
 
-        self.verticalLayout_3.addWidget(self.line_3)
+        self.verticalLayout_3.addWidget(self.frame_label_info)
 
-        self.group_base = QGroupBox(self.frame_sidebar)
+        self.frame_info_base = QFrame(self.frame_sidebar)
+        self.frame_info_base.setObjectName(u"frame_info_base")
+        self.frame_info_base.setFrameShape(QFrame.NoFrame)
+        self.frame_info_base.setFrameShadow(QFrame.Plain)
+        self.verticalLayout_11 = QVBoxLayout(self.frame_info_base)
+        self.verticalLayout_11.setObjectName(u"verticalLayout_11")
+        self.verticalLayout_11.setContentsMargins(0, 0, 0, 0)
+        self.label_13 = QLabel(self.frame_info_base)
+        self.label_13.setObjectName(u"label_13")
+
+        self.verticalLayout_11.addWidget(self.label_13)
+
+        self.label_filename_base = QLabel(self.frame_info_base)
+        self.label_filename_base.setObjectName(u"label_filename_base")
+        self.label_filename_base.setMargin(0)
+
+        self.verticalLayout_11.addWidget(self.label_filename_base)
+
+        self.group_base = QFrame(self.frame_info_base)
         self.group_base.setObjectName(u"group_base")
-        self.group_base.setStyleSheet(u"QGroupBox {\n"
-"border: 1px solid rgb(92, 92, 92);\n"
-"margin-top: 14px;\n"
-"padding-top:10px;\n"
-"}\n"
-"QGroupBox::title {\n"
-"subcontrol-origin: margin;\n"
-"subcontrol-position: top left;\n"
-"left: 8px;\n"
-"padding:0 5px;\n"
-"margin-top:5px;\n"
-"}")
-        self.group_base.setFlat(False)
-        self.group_base.setCheckable(False)
+        self.group_base.setFrameShape(QFrame.NoFrame)
+        self.group_base.setFrameShadow(QFrame.Raised)
         self.verticalLayout_18 = QVBoxLayout(self.group_base)
         self.verticalLayout_18.setSpacing(6)
         self.verticalLayout_18.setObjectName(u"verticalLayout_18")
-        self.verticalLayout_18.setContentsMargins(6, 6, 6, 6)
-        self.label_13 = QLabel(self.group_base)
-        self.label_13.setObjectName(u"label_13")
-
-        self.verticalLayout_18.addWidget(self.label_13)
-
+        self.verticalLayout_18.setContentsMargins(12, 6, 6, 6)
         self.frame_label_filename_base = QFrame(self.group_base)
         self.frame_label_filename_base.setObjectName(u"frame_label_filename_base")
         self.frame_label_filename_base.setFrameShape(QFrame.NoFrame)
@@ -451,12 +446,6 @@ class Ui_MainWindow(object):
         self.horizontalLayout_13 = QHBoxLayout(self.frame_label_filename_base)
         self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
         self.horizontalLayout_13.setContentsMargins(12, 0, 0, 0)
-        self.label_filename_base = QLabel(self.frame_label_filename_base)
-        self.label_filename_base.setObjectName(u"label_filename_base")
-        self.label_filename_base.setMargin(0)
-
-        self.horizontalLayout_13.addWidget(self.label_filename_base)
-
 
         self.verticalLayout_18.addWidget(self.frame_label_filename_base)
 
@@ -487,11 +476,6 @@ class Ui_MainWindow(object):
         self.verticalLayout_5 = QVBoxLayout(self.frame_subject)
         self.verticalLayout_5.setObjectName(u"verticalLayout_5")
         self.verticalLayout_5.setContentsMargins(0, 0, 0, 0)
-        self.label_4 = QLabel(self.frame_subject)
-        self.label_4.setObjectName(u"label_4")
-
-        self.verticalLayout_5.addWidget(self.label_4)
-
         self.frame_label_subjects = QFrame(self.frame_subject)
         self.frame_label_subjects.setObjectName(u"frame_label_subjects")
         self.frame_label_subjects.setFrameShape(QFrame.NoFrame)
@@ -499,73 +483,54 @@ class Ui_MainWindow(object):
         self.horizontalLayout_16 = QHBoxLayout(self.frame_label_subjects)
         self.horizontalLayout_16.setObjectName(u"horizontalLayout_16")
         self.horizontalLayout_16.setContentsMargins(12, 0, 0, 0)
-        self.label_subjects = QLabel(self.frame_label_subjects)
-        self.label_subjects.setObjectName(u"label_subjects")
-
-        self.horizontalLayout_16.addWidget(self.label_subjects)
-
 
         self.verticalLayout_5.addWidget(self.frame_label_subjects)
 
 
         self.verticalLayout_18.addWidget(self.frame_subject)
 
+        self.label_4 = QLabel(self.group_base)
+        self.label_4.setObjectName(u"label_4")
 
-        self.verticalLayout_3.addWidget(self.group_base)
+        self.verticalLayout_18.addWidget(self.label_4)
 
-        self.frame_mask = QFrame(self.frame_sidebar)
-        self.frame_mask.setObjectName(u"frame_mask")
-        self.frame_mask.setFrameShape(QFrame.NoFrame)
-        self.frame_mask.setFrameShadow(QFrame.Raised)
-        self.verticalLayout_4 = QVBoxLayout(self.frame_mask)
-        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
-        self.verticalLayout_4.setContentsMargins(0, 9, 0, 0)
-        self.pushButton_mask = QPushButton(self.frame_mask)
-        self.pushButton_mask.setObjectName(u"pushButton_mask")
+        self.label_subjects = QLabel(self.group_base)
+        self.label_subjects.setObjectName(u"label_subjects")
 
-        self.verticalLayout_4.addWidget(self.pushButton_mask)
-
-        self.checkBox_render_masks = QCheckBox(self.frame_mask)
-        self.checkBox_render_masks.setObjectName(u"checkBox_render_masks")
-
-        self.verticalLayout_4.addWidget(self.checkBox_render_masks)
+        self.verticalLayout_18.addWidget(self.label_subjects)
 
 
-        self.verticalLayout_3.addWidget(self.frame_mask)
+        self.verticalLayout_11.addWidget(self.group_base)
 
-        self.frame_8 = QFrame(self.frame_sidebar)
-        self.frame_8.setObjectName(u"frame_8")
-        self.frame_8.setFrameShape(QFrame.NoFrame)
-        self.frame_8.setFrameShadow(QFrame.Raised)
-        self.horizontalLayout_15 = QHBoxLayout(self.frame_8)
-        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
-        self.horizontalLayout_15.setContentsMargins(0, 0, 0, 0)
 
-        self.verticalLayout_3.addWidget(self.frame_8)
+        self.verticalLayout_3.addWidget(self.frame_info_base)
 
-        self.group_compare = QGroupBox(self.frame_sidebar)
+        self.frame_info_compare = QFrame(self.frame_sidebar)
+        self.frame_info_compare.setObjectName(u"frame_info_compare")
+        self.frame_info_compare.setFrameShape(QFrame.NoFrame)
+        self.frame_info_compare.setFrameShadow(QFrame.Plain)
+        self.verticalLayout_12 = QVBoxLayout(self.frame_info_compare)
+        self.verticalLayout_12.setObjectName(u"verticalLayout_12")
+        self.verticalLayout_12.setContentsMargins(0, 0, 0, 0)
+        self.label_8 = QLabel(self.frame_info_compare)
+        self.label_8.setObjectName(u"label_8")
+
+        self.verticalLayout_12.addWidget(self.label_8)
+
+        self.label_filename = QLabel(self.frame_info_compare)
+        self.label_filename.setObjectName(u"label_filename")
+        self.label_filename.setMargin(0)
+
+        self.verticalLayout_12.addWidget(self.label_filename)
+
+        self.group_compare = QFrame(self.frame_info_compare)
         self.group_compare.setObjectName(u"group_compare")
-        self.group_compare.setStyleSheet(u"QGroupBox {\n"
-"border: 1px solid rgb(92, 92, 92);\n"
-"margin-top: 14px;\n"
-"padding-top:10px;\n"
-"}\n"
-"QGroupBox::title {\n"
-"subcontrol-origin: margin;\n"
-"subcontrol-position: top left;\n"
-"left: 8px;\n"
-"padding:0 5px;\n"
-"margin-top:5px;\n"
-"}")
+        self.group_compare.setFrameShape(QFrame.NoFrame)
+        self.group_compare.setFrameShadow(QFrame.Raised)
         self.verticalLayout_19 = QVBoxLayout(self.group_compare)
         self.verticalLayout_19.setSpacing(6)
         self.verticalLayout_19.setObjectName(u"verticalLayout_19")
-        self.verticalLayout_19.setContentsMargins(6, 6, 9, 6)
-        self.label_8 = QLabel(self.group_compare)
-        self.label_8.setObjectName(u"label_8")
-
-        self.verticalLayout_19.addWidget(self.label_8)
-
+        self.verticalLayout_19.setContentsMargins(12, 6, 6, 6)
         self.frame_label_filename = QFrame(self.group_compare)
         self.frame_label_filename.setObjectName(u"frame_label_filename")
         self.frame_label_filename.setFrameShape(QFrame.NoFrame)
@@ -573,54 +538,8 @@ class Ui_MainWindow(object):
         self.verticalLayout_10 = QVBoxLayout(self.frame_label_filename)
         self.verticalLayout_10.setObjectName(u"verticalLayout_10")
         self.verticalLayout_10.setContentsMargins(12, 0, 0, 0)
-        self.label_filename = QLabel(self.frame_label_filename)
-        self.label_filename.setObjectName(u"label_filename")
-        self.label_filename.setMargin(0)
-
-        self.verticalLayout_10.addWidget(self.label_filename)
-
 
         self.verticalLayout_19.addWidget(self.frame_label_filename)
-
-        self.label_10 = QLabel(self.group_compare)
-        self.label_10.setObjectName(u"label_10")
-
-        self.verticalLayout_19.addWidget(self.label_10)
-
-        self.frame_label_opname = QFrame(self.group_compare)
-        self.frame_label_opname.setObjectName(u"frame_label_opname")
-        self.frame_label_opname.setFrameShape(QFrame.NoFrame)
-        self.frame_label_opname.setFrameShadow(QFrame.Raised)
-        self.verticalLayout_11 = QVBoxLayout(self.frame_label_opname)
-        self.verticalLayout_11.setObjectName(u"verticalLayout_11")
-        self.verticalLayout_11.setContentsMargins(12, 0, 0, 0)
-        self.label_opname = QLabel(self.frame_label_opname)
-        self.label_opname.setObjectName(u"label_opname")
-
-        self.verticalLayout_11.addWidget(self.label_opname)
-
-
-        self.verticalLayout_19.addWidget(self.frame_label_opname)
-
-        self.label_12 = QLabel(self.group_compare)
-        self.label_12.setObjectName(u"label_12")
-
-        self.verticalLayout_19.addWidget(self.label_12)
-
-        self.frame_label_modelname = QFrame(self.group_compare)
-        self.frame_label_modelname.setObjectName(u"frame_label_modelname")
-        self.frame_label_modelname.setFrameShape(QFrame.NoFrame)
-        self.frame_label_modelname.setFrameShadow(QFrame.Raised)
-        self.verticalLayout_12 = QVBoxLayout(self.frame_label_modelname)
-        self.verticalLayout_12.setObjectName(u"verticalLayout_12")
-        self.verticalLayout_12.setContentsMargins(12, 0, 0, 0)
-        self.label_modelname = QLabel(self.frame_label_modelname)
-        self.label_modelname.setObjectName(u"label_modelname")
-
-        self.verticalLayout_12.addWidget(self.label_modelname)
-
-
-        self.verticalLayout_19.addWidget(self.frame_label_modelname)
 
         self.label_9 = QLabel(self.group_compare)
         self.label_9.setObjectName(u"label_9")
@@ -643,72 +562,85 @@ class Ui_MainWindow(object):
         self.verticalLayout_19.addWidget(self.frame_label_shape)
 
 
-        self.verticalLayout_3.addWidget(self.group_compare)
+        self.verticalLayout_12.addWidget(self.group_compare)
 
-        self.group_postprocess = QGroupBox(self.frame_sidebar)
+
+        self.verticalLayout_3.addWidget(self.frame_info_compare)
+
+        self.frame_label_selection = QFrame(self.frame_sidebar)
+        self.frame_label_selection.setObjectName(u"frame_label_selection")
+        self.frame_label_selection.setFrameShape(QFrame.NoFrame)
+        self.frame_label_selection.setFrameShadow(QFrame.Raised)
+        self.layout_label_selection = QVBoxLayout(self.frame_label_selection)
+        self.layout_label_selection.setObjectName(u"layout_label_selection")
+        self.layout_label_selection.setContentsMargins(0, 12, 0, 0)
+        self.label_10 = QLabel(self.frame_label_selection)
+        self.label_10.setObjectName(u"label_10")
+        self.label_10.setFont(font5)
+
+        self.layout_label_selection.addWidget(self.label_10)
+
+
+        self.verticalLayout_3.addWidget(self.frame_label_selection)
+
+        self.frame_mask = QFrame(self.frame_sidebar)
+        self.frame_mask.setObjectName(u"frame_mask")
+        self.frame_mask.setFrameShape(QFrame.NoFrame)
+        self.frame_mask.setFrameShadow(QFrame.Raised)
+        self.verticalLayout_4 = QVBoxLayout(self.frame_mask)
+        self.verticalLayout_4.setObjectName(u"verticalLayout_4")
+        self.verticalLayout_4.setContentsMargins(0, 9, 0, 0)
+        self.pushButton_mask = QPushButton(self.frame_mask)
+        self.pushButton_mask.setObjectName(u"pushButton_mask")
+
+        self.verticalLayout_4.addWidget(self.pushButton_mask)
+
+        self.frame_mask_visibility = QFrame(self.frame_mask)
+        self.frame_mask_visibility.setObjectName(u"frame_mask_visibility")
+        self.frame_mask_visibility.setFrameShape(QFrame.NoFrame)
+        self.frame_mask_visibility.setFrameShadow(QFrame.Raised)
+        self.layout_mask_visibility = QVBoxLayout(self.frame_mask_visibility)
+        self.layout_mask_visibility.setObjectName(u"layout_mask_visibility")
+        self.layout_mask_visibility.setContentsMargins(0, 0, 0, 0)
+
+        self.verticalLayout_4.addWidget(self.frame_mask_visibility)
+
+
+        self.verticalLayout_3.addWidget(self.frame_mask)
+
+        self.frame_8 = QFrame(self.frame_sidebar)
+        self.frame_8.setObjectName(u"frame_8")
+        self.frame_8.setFrameShape(QFrame.NoFrame)
+        self.frame_8.setFrameShadow(QFrame.Raised)
+        self.horizontalLayout_15 = QHBoxLayout(self.frame_8)
+        self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
+        self.horizontalLayout_15.setContentsMargins(0, 0, 0, 0)
+
+        self.verticalLayout_3.addWidget(self.frame_8)
+
+        self.frame_label_operations = QFrame(self.frame_sidebar)
+        self.frame_label_operations.setObjectName(u"frame_label_operations")
+        self.frame_label_operations.setFrameShape(QFrame.NoFrame)
+        self.frame_label_operations.setFrameShadow(QFrame.Raised)
+        self.layout_label_operations = QVBoxLayout(self.frame_label_operations)
+        self.layout_label_operations.setObjectName(u"layout_label_operations")
+        self.layout_label_operations.setContentsMargins(0, 12, 0, 0)
+        self.label_11 = QLabel(self.frame_label_operations)
+        self.label_11.setObjectName(u"label_11")
+        self.label_11.setFont(font5)
+
+        self.layout_label_operations.addWidget(self.label_11)
+
+
+        self.verticalLayout_3.addWidget(self.frame_label_operations)
+
+        self.group_postprocess = QFrame(self.frame_sidebar)
         self.group_postprocess.setObjectName(u"group_postprocess")
-        self.group_postprocess.setStyleSheet(u"QGroupBox {\n"
-"border: 1px solid rgb(92, 92, 92);\n"
-"margin-top: 14px;\n"
-"padding-top:10px;\n"
-"}\n"
-"QGroupBox::title {\n"
-"subcontrol-origin: margin;\n"
-"subcontrol-position: top left;\n"
-"left: 8px;\n"
-"padding:0 5px;\n"
-"margin-top:5px;\n"
-"}")
+        self.group_postprocess.setFrameShape(QFrame.NoFrame)
+        self.group_postprocess.setFrameShadow(QFrame.Raised)
         self.verticalLayout_20 = QVBoxLayout(self.group_postprocess)
         self.verticalLayout_20.setObjectName(u"verticalLayout_20")
-        self.verticalLayout_20.setContentsMargins(6, 6, 6, 6)
-        self.frame_blur = QFrame(self.group_postprocess)
-        self.frame_blur.setObjectName(u"frame_blur")
-        self.frame_blur.setFrameShape(QFrame.NoFrame)
-        self.frame_blur.setFrameShadow(QFrame.Raised)
-        self.verticalLayout_71 = QVBoxLayout(self.frame_blur)
-        self.verticalLayout_71.setSpacing(6)
-        self.verticalLayout_71.setObjectName(u"verticalLayout_71")
-        self.verticalLayout_71.setContentsMargins(0, 0, 0, 9)
-        self.label_6 = QLabel(self.frame_blur)
-        self.label_6.setObjectName(u"label_6")
-
-        self.verticalLayout_71.addWidget(self.label_6)
-
-        self.frame_7 = QFrame(self.frame_blur)
-        self.frame_7.setObjectName(u"frame_7")
-        self.frame_7.setFrameShape(QFrame.NoFrame)
-        self.frame_7.setFrameShadow(QFrame.Raised)
-        self.horizontalLayout_6 = QHBoxLayout(self.frame_7)
-        self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
-        self.horizontalLayout_6.setContentsMargins(12, 0, 0, 0)
-        self.label_blur_amt = QLabel(self.frame_7)
-        self.label_blur_amt.setObjectName(u"label_blur_amt")
-        self.label_blur_amt.setMinimumSize(QSize(30, 0))
-
-        self.horizontalLayout_6.addWidget(self.label_blur_amt)
-
-        self.horizontalSlider_blur = QSlider(self.frame_7)
-        self.horizontalSlider_blur.setObjectName(u"horizontalSlider_blur")
-        self.horizontalSlider_blur.setOrientation(Qt.Horizontal)
-        self.horizontalSlider_blur.setTickPosition(QSlider.TicksBothSides)
-
-        self.horizontalLayout_6.addWidget(self.horizontalSlider_blur)
-
-
-        self.verticalLayout_71.addWidget(self.frame_7)
-
-        self.line_2 = QFrame(self.frame_blur)
-        self.line_2.setObjectName(u"line_2")
-        self.line_2.setStyleSheet(u"color: rgb(92, 92, 92);")
-        self.line_2.setFrameShadow(QFrame.Plain)
-        self.line_2.setFrameShape(QFrame.HLine)
-
-        self.verticalLayout_71.addWidget(self.line_2)
-
-
-        self.verticalLayout_20.addWidget(self.frame_blur)
-
+        self.verticalLayout_20.setContentsMargins(0, 0, 0, 0)
         self.frame_scale = QFrame(self.group_postprocess)
         self.frame_scale.setObjectName(u"frame_scale")
         self.frame_scale.setFrameShape(QFrame.NoFrame)
@@ -804,6 +736,21 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_3.addWidget(self.group_postprocess)
 
+        self.pushButton_run = QPushButton(self.frame_sidebar)
+        self.pushButton_run.setObjectName(u"pushButton_run")
+
+        self.verticalLayout_3.addWidget(self.pushButton_run)
+
+        self.pushButton_denoise = QPushButton(self.frame_sidebar)
+        self.pushButton_denoise.setObjectName(u"pushButton_denoise")
+
+        self.verticalLayout_3.addWidget(self.pushButton_denoise)
+
+        self.pushButton_upscale = QPushButton(self.frame_sidebar)
+        self.pushButton_upscale.setObjectName(u"pushButton_upscale")
+
+        self.verticalLayout_3.addWidget(self.pushButton_upscale)
+
 
         self.horizontalLayout.addWidget(self.frame_sidebar, 0, Qt.AlignTop)
 
@@ -836,10 +783,10 @@ class Ui_MainWindow(object):
         self.horizontalLayout_12.setContentsMargins(0, 0, 0, 0)
         self.label = QLabel(self.frame_10)
         self.label.setObjectName(u"label")
-        font5 = QFont()
-        font5.setPointSize(12)
-        font5.setBold(True)
-        self.label.setFont(font5)
+        font6 = QFont()
+        font6.setPointSize(12)
+        font6.setBold(True)
+        self.label.setFont(font6)
 
         self.horizontalLayout_12.addWidget(self.label)
 
@@ -960,36 +907,29 @@ class Ui_MainWindow(object):
         self.canvas_main.setText(QCoreApplication.translate("MainWindow", u"TextLabel", None))
         self.pushButton_open.setText(QCoreApplication.translate("MainWindow", u"Open", None))
         self.pushButton_clear.setText(QCoreApplication.translate("MainWindow", u"Clear", None))
-        self.pushButton_run.setText(QCoreApplication.translate("MainWindow", u"Sharpen", None))
-        self.pushButton_denoise.setText(QCoreApplication.translate("MainWindow", u"Denoise", None))
-        self.pushButton_upscale.setText(QCoreApplication.translate("MainWindow", u"Upscale", None))
         self.pushButton_modelManager.setText(QCoreApplication.translate("MainWindow", u"Model Manager", None))
-        self.group_base.setTitle(QCoreApplication.translate("MainWindow", u"Base File", None))
-        self.label_13.setText(QCoreApplication.translate("MainWindow", u"Filename:", None))
+        self.label_7.setText(QCoreApplication.translate("MainWindow", u"IMAGE INFO", None))
+        self.label_13.setText(QCoreApplication.translate("MainWindow", u"Input file:", None))
         self.label_filename_base.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><span style=\" color:#9a9996;\"/></p></body></html>", None))
         self.label_14.setText(QCoreApplication.translate("MainWindow", u"Shape:", None))
         self.label_shape_base.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p/></body></html>", None))
         self.label_4.setText(QCoreApplication.translate("MainWindow", u"Subjects:", None))
         self.label_subjects.setText("")
-        self.pushButton_mask.setText(QCoreApplication.translate("MainWindow", u"Auto Mask", None))
-        self.checkBox_render_masks.setText(QCoreApplication.translate("MainWindow", u"Render Masks", None))
-        self.group_compare.setTitle(QCoreApplication.translate("MainWindow", u"Compare File", None))
-        self.label_8.setText(QCoreApplication.translate("MainWindow", u"Filename:", None))
+        self.label_8.setText(QCoreApplication.translate("MainWindow", u"Enhanced File:", None))
         self.label_filename.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><span style=\" color:#9a9996;\"/></p></body></html>", None))
-        self.label_10.setText(QCoreApplication.translate("MainWindow", u"Operation:", None))
-        self.label_opname.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><span style=\" color:#9a9996;\"/></p></body></html>", None))
-        self.label_12.setText(QCoreApplication.translate("MainWindow", u"Model:", None))
-        self.label_modelname.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p><span style=\" color:#9a9996;\"/></p></body></html>", None))
         self.label_9.setText(QCoreApplication.translate("MainWindow", u"Shape:", None))
         self.label_shape.setText(QCoreApplication.translate("MainWindow", u"<html><head/><body><p/></body></html>", None))
-        self.group_postprocess.setTitle(QCoreApplication.translate("MainWindow", u"Operations", None))
-        self.label_6.setText(QCoreApplication.translate("MainWindow", u"Blur:", None))
-        self.label_blur_amt.setText(QCoreApplication.translate("MainWindow", u"0", None))
+        self.label_10.setText(QCoreApplication.translate("MainWindow", u"SELECTION", None))
+        self.pushButton_mask.setText(QCoreApplication.translate("MainWindow", u"Auto Mask", None))
+        self.label_11.setText(QCoreApplication.translate("MainWindow", u"OPERATIONS", None))
         self.label_5.setText(QCoreApplication.translate("MainWindow", u"Downscale:", None))
         self.label_scale.setText("")
         self.label_blend.setText(QCoreApplication.translate("MainWindow", u"Blend Original Image:", None))
         self.label_blend_amt.setText(QCoreApplication.translate("MainWindow", u"0%", None))
         self.pushButton_postprocess_apply.setText(QCoreApplication.translate("MainWindow", u"Apply", None))
+        self.pushButton_run.setText(QCoreApplication.translate("MainWindow", u"Sharpen", None))
+        self.pushButton_denoise.setText(QCoreApplication.translate("MainWindow", u"Denoise", None))
+        self.pushButton_upscale.setText(QCoreApplication.translate("MainWindow", u"Upscale", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Files", None))
         self.label_files_count.setText("")
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"text", None))

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -194,7 +194,7 @@ class Ui_AppWindow(Ui_MainWindow):
         self.selectionManager.clear()
         self._clearOperationWidgets()
         self.currentCompareFile = None
-        self.maskVisibilityList.setMasks([])
+        self.maskVisibilityList.set_masks([])
         self.group_base.hide()
         self.frame_info_compare.hide()
         self.group_compare.hide()
@@ -210,7 +210,7 @@ class Ui_AppWindow(Ui_MainWindow):
             self.app.clearFileList()
             self._clearOperationWidgets()
             self.currentCompareFile = None
-            self.maskVisibilityList.setMasks([])
+            self.maskVisibilityList.set_masks([])
             self.group_base.hide()
             self.frame_info_compare.hide()
             self.group_compare.hide()
@@ -225,14 +225,14 @@ class Ui_AppWindow(Ui_MainWindow):
         result = dialog.exec()
         if result == QDialog.Accepted:
             # Hide masks before running operation
-            self.maskVisibilityList.setAllVisible(False)
+            self.maskVisibilityList.set_all_visible(False)
 
             selectedItems = dialog.ui.listWidget.selectedItems()
             tileSize = int(dialog.ui.tileSize_combobox.currentText())
             tilePadding = int(dialog.ui.tilePadding_combobox.currentText())
             gpuId = dialog.ui.device_combobox.currentData()
             maintainScale = dialog.ui.checkBox_maintainScale.isChecked()
-            selectedMasks = dialog.ui.getSelectedMasks()
+            selectedMasks = dialog.ui.get_selected_masks()
 
             desc = "Sharpen"
             if operation == Operation.Upscale:
@@ -532,19 +532,19 @@ class Ui_AppWindow(Ui_MainWindow):
 
         availableMasks = self.app.baseFile.masks
         for widget in self.operationWidgets:
-            widget.updateAvailableMasks(availableMasks)
+            widget.update_available_masks(availableMasks)
 
         # Also update the visibility list
         self._updateMaskVisibilityList()
 
     def _updateMaskVisibilityList(self):
         if not self.app.baseFile or not hasattr(self.app.baseFile, "masks"):
-            self.maskVisibilityList.setMasks([])
+            self.maskVisibilityList.set_masks([])
             return
 
-        self.maskVisibilityList.setMasks(self.app.baseFile.masks)
+        self.maskVisibilityList.set_masks(self.app.baseFile.masks)
         # Show all masks by default when first generated
-        self.maskVisibilityList.setAllVisible(True)
+        self.maskVisibilityList.set_all_visible(True)
 
     def _onOperationStrengthChanged(self, operation: AppliedOperation, strength: float):
         """Handle strength change from an operation widget - debounced."""
@@ -577,7 +577,7 @@ class Ui_AppWindow(Ui_MainWindow):
         for i, widget in enumerate(self.operationWidgets):
             op = widget.operation
             if op.supportsStrength():
-                newStrength = widget.getStrength()
+                newStrength = widget.get_strength()
                 if op.strength != newStrength:
                     op.strength = newStrength
                     if earliestChangedIndex is None:

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -112,6 +112,8 @@ class Ui_AppWindow(Ui_MainWindow):
         self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
+        self.pushButton_saveFile.hide()
+        self.pushButton_delete.hide()
 
         # Make filename labels clickable to toggle detail frames
         self.label_filename_base.setCursor(Qt.PointingHandCursor)
@@ -134,6 +136,12 @@ class Ui_AppWindow(Ui_MainWindow):
         self.pushButton_modelManager.clicked.connect(lambda: self.showModelManager())
         self.pushButton_zoom.clicked.connect(self.showZoomMenu)
         self.pushButton_taskQueue.clicked.connect(self.showTaskQueue)
+        self.pushButton_saveFile.clicked.connect(
+            lambda: self.saveFile(self.currentCompareFile, None)
+        )
+        self.pushButton_delete.clicked.connect(
+            lambda: self.removeFile(self.currentCompareFile, None)
+        )
         self.pushButton_single.clicked.connect(
             lambda: self.canvas_main.setRenderMode(RenderMode.Single)
         )
@@ -199,6 +207,8 @@ class Ui_AppWindow(Ui_MainWindow):
         self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
+        self.pushButton_saveFile.hide()
+        self.pushButton_delete.hide()
 
     def showOpenDialog(self):
         path, _ = QFileDialog.getOpenFileName(
@@ -215,6 +225,8 @@ class Ui_AppWindow(Ui_MainWindow):
             self.frame_info_compare.hide()
             self.group_compare.hide()
             self.group_postprocess.hide()
+            self.pushButton_saveFile.hide()
+            self.pushButton_delete.hide()
             self.signals.selectBaseFile.emit(file, True)
             self.signals.drawFileList.emit(file)
             self.renderBaseFile()
@@ -374,6 +386,15 @@ class Ui_AppWindow(Ui_MainWindow):
         self.app.removeFile(file)
         self.selectionManager.removeFile(file)
         self.fileStrip.removeButton(file)
+
+        # Update sidebar if we removed the current compare file
+        if file == self.currentCompareFile:
+            self.currentCompareFile = None
+            nextCompare = self.selectionManager.getCompareFile(0)
+            self.renderPostProcess(nextCompare)
+            # Switch to single view if no compare file is selected
+            if nextCompare is None:
+                self.canvas_main.setRenderMode(RenderMode.Single)
 
     def createOutputFile(self):
         """Create a new OutputFile from the current base file"""
@@ -659,6 +680,8 @@ class Ui_AppWindow(Ui_MainWindow):
         self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
+        self.pushButton_saveFile.hide()
+        self.pushButton_delete.hide()
 
         if compareFile is None:
             compareFile = self.selectionManager.getCompareFile(0)
@@ -666,6 +689,10 @@ class Ui_AppWindow(Ui_MainWindow):
         self.currentCompareFile = compareFile
 
         if compareFile is not None and isinstance(compareFile, OutputFile):
+            # Always show save/delete buttons for OutputFiles
+            self.pushButton_saveFile.show()
+            self.pushButton_delete.show()
+
             if compareFile.operations:
                 # Update the compare file info panel
                 firstOp = compareFile.getFirstOperation()

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -519,12 +519,6 @@ class Ui_AppWindow(Ui_MainWindow):
         """When masks change, we need to re-run the operation from scratch since
         the mask affects which pixels are processed by the model.
         """
-        # Check if anything actually changed - compare labels and inverted states
-        currentMaskKey = set((m.uniqueLabel, m.inverted) for m in operation.masks)
-        newMaskKey = set((m.uniqueLabel, m.inverted) for m in masks)
-        if currentMaskKey == newMaskKey:
-            return
-
         # Update the operation's masks
         operation.masks = masks
 
@@ -540,27 +534,44 @@ class Ui_AppWindow(Ui_MainWindow):
         if not isinstance(compareFile, OutputFile):
             return
 
-        # Update strengths from widgets and reapply
-        anyChanged = False
-        for widget in self.operationWidgets:
+        # Find the earliest operation whose strength changed
+        earliestChangedIndex = None
+        for i, widget in enumerate(self.operationWidgets):
             op = widget.operation
             if op.supportsStrength():
                 newStrength = widget.getStrength()
                 if op.strength != newStrength:
                     op.strength = newStrength
-                    compareFile.reapplyStrength(op)
-                    anyChanged = True
+                    if earliestChangedIndex is None:
+                        earliestChangedIndex = i
 
-        if anyChanged:
-            button = self.fileStrip.getButton(compareFile)
-            if button:
-                button.updateTextLabel()
-            self.signals.showFiles.emit(False)
-            self.signals.updateIndicator.emit(compareFile, SAVE_STATE_CHANGED)
+        if earliestChangedIndex is None:
+            return
+
+        # If there are subsequent operations, re-run them through the model
+        # since their input has changed
+        nextIndex = earliestChangedIndex + 1
+        if nextIndex < len(compareFile.operations):
+            self._rerunOperationChain(compareFile.operations[nextIndex])
+        else:
+            # Only the last operation changed - just re-blend, no model re-run needed
+            def applyStrength():
+                compareFile.reapplyStrength(compareFile.operations[earliestChangedIndex])
+
+                # Update UI
+                self.signals.selectCompareFile.emit(compareFile)
+                self.signals.updateIndicator.emit(compareFile, SAVE_STATE_CHANGED)
+                self.signals.taskCompleted.emit()
+
+            worker = AsyncWorker(
+                applyStrength,
+                label="Applying strength",
+                device=self.app.gpuInfo.getPreferredDevice(),
+            )
+            self.op_queue.start(worker)
 
     def _rerunOperationChain(self, startOperation: AppliedOperation):
         """Re-run operations starting from the given operation."""
-
         if self.currentCompareFile is None or not isinstance(
             self.currentCompareFile, OutputFile
         ):
@@ -572,35 +583,47 @@ class Ui_AppWindow(Ui_MainWindow):
             logger.warning("Operation not found in file")
             return
 
-        def rerunOps():
-            progressUpdater = ProgressBarUpdater(
-                self.progressBar,
-                self.label_progressBar,
-                total=1,
-                desc="Re-running operations",
+        # Prepare: remove ops from startIndex onward and reset file state
+        opsToRerun = self.app.prepareRerunChain(compareFile, opIndex)
+
+        if not opsToRerun:
+            return
+
+        # Queue each operation as a separate job
+        for i, op in enumerate(opsToRerun):
+            isLast = (i == len(opsToRerun) - 1)
+            desc = f"{op.operation_type.value.capitalize()} (re-run)"
+
+            def f(op=op, isLast=isLast):
+                def rerunJob():
+                    progressUpdater = ProgressBarUpdater(
+                        self.progressBar,
+                        self.label_progressBar,
+                        total=1,
+                        desc=desc,
+                    )
+
+                    success = self.app.rerunSingleOperation(
+                        compareFile,
+                        op,
+                        progressCallback=progressUpdater.tick,
+                    )
+
+                    if not success:
+                        logger.error(f"Failed to re-run operation: {op.operation_type}")
+                        return
+
+                    if isLast:
+                        self.signals.selectCompareFile.emit(compareFile)
+                    self.signals.taskCompleted.emit()
+                return rerunJob
+
+            worker = AsyncWorker(
+                f(),
+                label=f"{desc}: {op.model}",
+                device=self.app.gpuInfo.getPreferredDevice(),
             )
-
-            success = self.app.rerunOperationChain(
-                compareFile,
-                opIndex,
-                progressCallback=progressUpdater.tick,
-            )
-
-            if not success:
-                logger.error("Failed to re-run operation chain")
-                return
-
-            # Update UI
-            self.signals.selectCompareFile.emit(compareFile)
-            self.signals.taskCompleted.emit()
-
-        # Run async
-        worker = AsyncWorker(
-            rerunOps,
-            label="Re-running operations",
-            device=self.app.gpuInfo.getPreferredDevice(),
-        )
-        self.op_queue.start(worker)
+            self.op_queue.start(worker)
 
     def renderPostProcess(self, compareFile: OutputFile):
         self.group_compare.hide()

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -645,7 +645,7 @@ class Ui_AppWindow(Ui_MainWindow):
             isLast = (i == len(opsToRerun) - 1)
             desc = f"{op.operation_type.value.capitalize()} (re-run)"
 
-            def f(op=op, isLast=isLast):
+            def f(op=op, isLast=isLast, desc=desc):
                 def rerunJob():
                     progressUpdater = ProgressBarUpdater(
                         self.progressBar,

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -251,42 +251,33 @@ class Ui_AppWindow(Ui_MainWindow):
                     self.progressBar, self.label_progressBar, total=1, desc=desc
                 )
 
-                # If we have a selected OutputFile, append operation to it
-                if compareFile is not None and isinstance(compareFile, OutputFile):
-                    result = self.app.runModelOnExisting(
-                        compareFile,
-                        selectedModel,
-                        progressUpdater.tick,
-                        tileSize,
-                        tilePadding,
-                        maintainScale,
-                        gpuId,
-                        operation,
-                        masks=selectedMasks if selectedMasks else None,
-                    )
-                    if result is None:
+                # If no OutputFile is selected, create one from the base file first.
+                # This ensures the file exists in the UI before the operation starts,
+                # allowing additional operations to be chained onto it.
+                if compareFile is None or not isinstance(compareFile, OutputFile):
+                    compareFile = self.app.createOutputFile(baseFile)
+                    if compareFile is None:
                         return
-                    # Update the file button to reflect changes
-                    self.signals.selectCompareFile.emit(result)
-                    self.signals.taskCompleted.emit()
-                else:
-                    # No OutputFile selected, create a new one from base file
-                    result = self.app.runModel(
-                        baseFile,
-                        selectedModel,
-                        progressUpdater.tick,
-                        tileSize,
-                        tilePadding,
-                        maintainScale,
-                        gpuId,
-                        operation,
-                        masks=selectedMasks if selectedMasks else None,
-                    )
-                    if result is None:
-                        return
-                    self.signals.appendFile.emit(result)
-                    self.signals.selectCompareFile.emit(result)
-                    self.signals.taskCompleted.emit()
+                    self.app.rawFiles.append(compareFile)
+                    self.signals.appendFile.emit(compareFile)
+                    self.signals.selectCompareFile.emit(compareFile)
+
+                result = self.app.runModelOnExisting(
+                    compareFile,
+                    selectedModel,
+                    progressUpdater.tick,
+                    tileSize,
+                    tilePadding,
+                    maintainScale,
+                    gpuId,
+                    operation,
+                    masks=selectedMasks if selectedMasks else None,
+                )
+                if result is None:
+                    return
+                # Update the file button to reflect changes
+                self.signals.selectCompareFile.emit(result)
+                self.signals.taskCompleted.emit()
 
             for selectedItem in selectedItems:
                 selectedModel = selectedItem.text()
@@ -396,6 +387,7 @@ class Ui_AppWindow(Ui_MainWindow):
             self.app.rawFiles.append(outputFile)
             self.signals.appendFile.emit(outputFile)
             self.selectionManager.selectCompare(outputFile)
+            self.signals.selectCompareFile.emit(outputFile)
 
     def saveFile(self, file: OutputFile, button: FileButton):
         if file is not None:

--- a/src/enhance/ui/ui_wrap.py
+++ b/src/enhance/ui/ui_wrap.py
@@ -38,6 +38,7 @@ from enhance.ui.ui_dialog_model_wrap import DialogModel
 from enhance.ui.ui_dialog_taskqueue_wrap import DialogTaskQueue
 from enhance.ui.ui_interface import Ui_MainWindow
 from enhance.ui.common import RenderMode, ZoomLevel
+from enhance.ui.mask_visibility_list import MaskVisibilityList
 
 
 class MainWindow(QMainWindow):
@@ -107,8 +108,20 @@ class Ui_AppWindow(Ui_MainWindow):
         self._setupOperationsContainer()
 
         # Hide optional panels
+        self.group_base.hide()
+        self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
+
+        # Make filename labels clickable to toggle detail frames
+        self.label_filename_base.setCursor(Qt.PointingHandCursor)
+        self.label_filename_base.mousePressEvent = (
+            lambda _: self._toggleFrameVisibility(self.group_base)
+        )
+        self.label_filename.setCursor(Qt.PointingHandCursor)
+        self.label_filename.mousePressEvent = lambda _: self._toggleFrameVisibility(
+            self.group_compare
+        )
 
         # Bind events
         self.pushButton_cancelOp.clicked.connect(self.cancelOp)
@@ -130,8 +143,11 @@ class Ui_AppWindow(Ui_MainWindow):
         self.pushButton_quad.clicked.connect(
             lambda: self.canvas_main.setRenderMode(RenderMode.Grid)
         )
-        self.checkBox_render_masks.stateChanged.connect(
-            lambda state: self.canvas_main.setShowMasks(state != 0)
+
+        self.maskVisibilityList = MaskVisibilityList()
+        self.frame_mask_visibility.layout().addWidget(self.maskVisibilityList)
+        self.maskVisibilityList.visibilityChanged.connect(
+            lambda indices: self.canvas_main.setVisibleMasks(indices)
         )
 
         self.signals.incrementProgress.connect(self.incrementProgressBar)
@@ -168,6 +184,9 @@ class Ui_AppWindow(Ui_MainWindow):
 
         self.updateGPUStats()
 
+    def _toggleFrameVisibility(self, frame):
+        frame.setVisible(not frame.isVisible())
+
     def clear(self):
         self.app.setBaseFile(None)
         self.app.clearFileList()
@@ -175,6 +194,9 @@ class Ui_AppWindow(Ui_MainWindow):
         self.selectionManager.clear()
         self._clearOperationWidgets()
         self.currentCompareFile = None
+        self.maskVisibilityList.setMasks([])
+        self.group_base.hide()
+        self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
 
@@ -188,6 +210,9 @@ class Ui_AppWindow(Ui_MainWindow):
             self.app.clearFileList()
             self._clearOperationWidgets()
             self.currentCompareFile = None
+            self.maskVisibilityList.setMasks([])
+            self.group_base.hide()
+            self.frame_info_compare.hide()
             self.group_compare.hide()
             self.group_postprocess.hide()
             self.signals.selectBaseFile.emit(file, True)
@@ -199,6 +224,9 @@ class Ui_AppWindow(Ui_MainWindow):
         dialog = DialogModel(self.app, [operation])
         result = dialog.exec()
         if result == QDialog.Accepted:
+            # Hide masks before running operation
+            self.maskVisibilityList.setAllVisible(False)
+
             selectedItems = dialog.ui.listWidget.selectedItems()
             tileSize = int(dialog.ui.tileSize_combobox.currentText())
             tilePadding = int(dialog.ui.tilePadding_combobox.currentText())
@@ -297,7 +325,6 @@ class Ui_AppWindow(Ui_MainWindow):
                 )
                 self.app.runAutoMask(file, progressUpdater.tick)
                 self.signals.showFiles.emit(False)
-                self.checkBox_render_masks.setChecked(True)
                 self.signals.updateOperationWidgetMasks.emit()
                 self.signals.taskCompleted.emit()
 
@@ -457,7 +484,6 @@ class Ui_AppWindow(Ui_MainWindow):
         """Set up the container for dynamically-created operation widgets."""
         # Clear the existing postprocess group contents and replace with a vertical layout
         # Hide the old static controls
-        self.frame_blur.hide()
         self.frame_scale.hide()
         self.frame_blend.hide()
         self.pushButton_postprocess_apply.hide()
@@ -507,6 +533,18 @@ class Ui_AppWindow(Ui_MainWindow):
         availableMasks = self.app.baseFile.masks
         for widget in self.operationWidgets:
             widget.updateAvailableMasks(availableMasks)
+
+        # Also update the visibility list
+        self._updateMaskVisibilityList()
+
+    def _updateMaskVisibilityList(self):
+        if not self.app.baseFile or not hasattr(self.app.baseFile, "masks"):
+            self.maskVisibilityList.setMasks([])
+            return
+
+        self.maskVisibilityList.setMasks(self.app.baseFile.masks)
+        # Show all masks by default when first generated
+        self.maskVisibilityList.setAllVisible(True)
 
     def _onOperationStrengthChanged(self, operation: AppliedOperation, strength: float):
         """Handle strength change from an operation widget - debounced."""
@@ -626,6 +664,7 @@ class Ui_AppWindow(Ui_MainWindow):
             self.op_queue.start(worker)
 
     def renderPostProcess(self, compareFile: OutputFile):
+        self.frame_info_compare.hide()
         self.group_compare.hide()
         self.group_postprocess.hide()
 
@@ -641,14 +680,6 @@ class Ui_AppWindow(Ui_MainWindow):
                 self.drawLabelText(
                     self.label_filename, compareFile.basename, maybeElide=True
                 )
-                self.drawLabelText(
-                    self.label_opname, firstOp.operation_type.value if firstOp else ""
-                )
-                self.drawLabelText(
-                    self.label_modelname,
-                    firstOp.model if firstOp else "",
-                    maybeElide=True,
-                )
 
                 compareImg = compareFile.loadUnchanged()
                 self.drawLabelShape(self.label_shape, compareImg)
@@ -656,7 +687,7 @@ class Ui_AppWindow(Ui_MainWindow):
                 # Create operation widgets for all operations
                 self._createOperationWidgets(compareFile)
 
-                self.group_compare.show()
+                self.frame_info_compare.show()
                 self.group_postprocess.show()
 
     def drawLabelText(self, label, text, maybeElide=False):
@@ -664,8 +695,10 @@ class Ui_AppWindow(Ui_MainWindow):
             metrics = QFontMetrics(label.font())
             clippedText = metrics.elidedText(text, Qt.TextElideMode.ElideMiddle, 200)
             label.setText(clippedText)
+            label.setToolTip(text)
         else:
             label.setText(text)
+            label.setToolTip("")
         label.setStyleSheet("color: #aaa;")
 
     def drawLabelShape(self, label, img):


### PR DESCRIPTION
Merge branch with support for automatic masking and model chaining.

Auto-masking:
- Mainline dependencies on Florence and SAM2. We're able to do this without flash-attn, which was previously a blocker.
- Add UI support for auto-masking.
  - First, when a new input file is loaded, automatically detect subjects, returning bounding boxes and labels.
  - User can then "Auto Mask" to generate a refined subject mask within each bounding box.

Model chaining:
- The target use case is enabling user to denoise a region of the image, then sharpen another region. The implementation also permits a user to apply multiple models of the same type (eg. sharpen, then sharpen more).
- In the chain, the output from one model operation is the input to the next operation. If post-processing parameters are changed (eg. strength is reduced), any following model operations in the chain need to be recomputed.